### PR TITLE
Fix for code scanning alerts: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}-lint
   cancel-in-progress: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.ref }}-tests
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lunal-dev/attestation-go/security/code-scanning/1](https://github.com/lunal-dev/attestation-go/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this lint workflow, the minimal safe baseline is:

- `contents: read`

Place it after the `on:` section (or another top-level location) and before `concurrency:`/`jobs:` for clarity. No imports, methods, or external dependencies are needed—just YAML config update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
