### PR TITLE
feat(snp): derive AMD roots from VCEK for unclassifiable CPUIDs 

### DIFF
--- a/attestation/snp/snp.go
+++ b/attestation/snp/snp.go
@@ -8,6 +8,7 @@
 package snp
 
 import (
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -18,7 +19,6 @@ import (
 	"github.com/google/go-sev-guest/validate"
 	sv "github.com/google/go-sev-guest/verify"
 	"github.com/google/go-sev-guest/verify/trust"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 )
@@ -101,10 +101,21 @@ func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, pla
 	// Getter is supplied for CRL/cert fetching.
 	verifyOpts := sv.DefaultOptions()
 	verifyOpts.CheckRevocations = opts.CheckRevocations
-	verifyOpts.Product = productFromReport(report)
+	verifyOpts.Product = abi.SevProductFromCpuid1Eax(report.GetCpuid1EaxFms())
 	verifyOpts.DisableCertFetching = opts.Getter == nil
 	if opts.Getter != nil {
 		verifyOpts.Getter = opts.Getter
+	}
+	// go-sev-guest selects its bundled AMD roots by the product line it derives
+	// from the report's CPUID. For parts its table doesn't know — notably Zen4c
+	// (Bergamo/Siena), family 0x19 model 0xA0 — that yields "Unknown" and offline
+	// root selection fails; back-fill the roots from the VCEK certificate instead.
+	roots, err := vcekProductRoots(report, vcekDER)
+	if err != nil {
+		return nil, err
+	}
+	if roots != nil {
+		verifyOpts.TrustedRoots = roots
 	}
 	if err := sv.SnpAttestation(attestation, verifyOpts); err != nil {
 		return nil, fmt.Errorf("snp: hardware verification failed: %w", err)
@@ -178,29 +189,41 @@ func pad(b []byte, n int) []byte {
 	return out
 }
 
-// productFromReport resolves the AMD product (which selects the embedded ARK/ASK
-// roots) from the report's CPUID. go-sev-guest recognizes the canonical model
-// IDs; for the Genoa-family 0xA0 range (Bergamo/Siena and some Genoa SKUs) its
-// detection returns Unknown, so we fall back to the same family/model mapping
-// attestation-rs uses, keeping verification offline.
-func productFromReport(report *spb.Report) *spb.SevProduct {
+// vcekProductRoots back-fills trusted roots for parts go-sev-guest cannot
+// classify from a v3 report's CPUID (so it would fail offline anchoring under
+// product line "Unknown") — notably Zen4c (Bergamo/Siena), whose VCEKs chain to
+// the Genoa roots. It reads the authoritative product line from the VCEK
+// certificate (the same source go-sev-guest uses for v2 reports) and supplies the
+// matching bundled roots, keyed under the line go-sev-guest derives for the
+// report.
+//
+// It returns (nil, nil) — leaving go-sev-guest's own root selection untouched —
+// when there is no VCEK, the report is v2 (product already comes from the VCEK),
+// go-sev-guest can classify the CPUID itself, or the VCEK's product line is also
+// unknown to go-sev-guest (that part genuinely needs upstream support).
+func vcekProductRoots(report *spb.Report, vcekDER []byte) (map[string][]*trust.AMDRootCerts, error) {
 	fms := report.GetCpuid1EaxFms()
-	if p := abi.SevProductFromCpuid1Eax(fms); p.GetName() != spb.SevProduct_SEV_PRODUCT_UNKNOWN {
-		return p
+	if fms == 0 || len(vcekDER) == 0 {
+		return nil, nil // v2 report or no VCEK: nothing to back-fill.
 	}
-	family, model, stepping := abi.FmsFromCpuid1Eax(fms)
-	var name spb.SevProduct_SevProductName
-	switch {
-	case family == 0x19 && model <= 0x0F:
-		name = spb.SevProduct_SEV_PRODUCT_MILAN
-	case family == 0x19 && ((model >= 0x10 && model <= 0x1F) || (model >= 0xA0 && model <= 0xAF)):
-		name = spb.SevProduct_SEV_PRODUCT_GENOA
-	case family == 0x1A && model <= 0x11:
-		name = spb.SevProduct_SEV_PRODUCT_TURIN
-	default:
-		return abi.SevProductFromCpuid1Eax(fms) // leave Unknown; verify reports it
+	reportLine := kds.ProductLineFromFms(fms)
+	if _, err := trust.GetDefaultRootCerts(reportLine); err == nil {
+		return nil, nil // go-sev-guest can anchor this part itself.
 	}
-	return &spb.SevProduct{Name: name, MachineStepping: wrapperspb.UInt32(uint32(stepping))}
+	cert, err := x509.ParseCertificate(vcekDER)
+	if err != nil {
+		return nil, fmt.Errorf("snp: parsing VCEK for product fallback: %w", err)
+	}
+	exts, err := kds.VcekCertificateExtensions(cert)
+	if err != nil {
+		return nil, fmt.Errorf("snp: reading VCEK product extension: %w", err)
+	}
+	root, err := trust.GetDefaultRootCerts(kds.ProductLineOfProductName(exts.ProductName))
+	if err != nil {
+		return nil, nil // VCEK's product line is also unknown to go-sev-guest.
+	}
+	// Hand go-sev-guest the bundled roots under the line it derives for this report.
+	return map[string][]*trust.AMDRootCerts{reportLine: {root}}, nil
 }
 
 // extractClaims normalizes an SNP report into teetypes.Claims (mirrors

--- a/attestation/snp/snp_test.go
+++ b/attestation/snp/snp_test.go
@@ -2,10 +2,10 @@ package snp
 
 import (
 	_ "embed"
-	"encoding/base64"
 	"encoding/json"
-	"strings"
 	"testing"
+
+	spb "github.com/google/go-sev-guest/proto/sevsnp"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 )
@@ -60,10 +60,10 @@ func TestVerifyEvidence_Errors(t *testing.T) {
 	}
 }
 
-// TestVerifyEvidence_BareMetalEnvelope drives the bare-metal envelope path with
-// a real Genoa-family v5 fixture. go-sev-guest v0.15 doesn't recognize the
-// 0xA0 (Bergamo/Siena) CPU model offline, so it can't pick embedded roots for
-// it; the test skips with that documented limitation rather than failing.
+// TestVerifyEvidence_BareMetalEnvelope drives the bare-metal envelope path with a
+// real Genoa-family fixture whose CPUID model (0xA0, Bergamo/Siena) go-sev-guest
+// cannot classify offline. vcekProductRoots back-fills the Genoa roots from the
+// VCEK certificate so verification succeeds end to end.
 func TestVerifyEvidence_BareMetalEnvelope(t *testing.T) {
 	var env struct {
 		Evidence json.RawMessage `json:"evidence"`
@@ -75,18 +75,43 @@ func TestVerifyEvidence_BareMetalEnvelope(t *testing.T) {
 	if err := json.Unmarshal(env.Evidence, &ev); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := base64.StdEncoding.DecodeString(ev.AttestationReport); err != nil {
-		t.Fatalf("envelope report should be valid base64: %v", err)
-	}
 
 	res, err := VerifyEvidence(ev, teetypes.VerifyParams{}, Options{})
 	if err != nil {
-		if strings.Contains(err.Error(), "Unknown") || strings.Contains(err.Error(), "no embedded roots") {
-			t.Skipf("known go-sev-guest gap: Genoa-family model 0xA0 (Bergamo/Siena) product not recognized offline: %v", err)
-		}
 		t.Fatalf("VerifyEvidence: %v", err)
 	}
-	if res.Platform != teetypes.PlatformSNP {
-		t.Fatalf("platform = %s", res.Platform)
+	if !res.SignatureValid || res.Platform != teetypes.PlatformSNP {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if len(res.Claims.LaunchDigest) != 96 || res.Claims.TCB.Type != "Snp" {
+		t.Fatalf("unexpected claims: %+v", res.Claims)
 	}
 }
+
+// TestVCEKProductRoots_Guards covers the cases where the VCEK product fallback
+// must stay out of go-sev-guest's way and return no override.
+func TestVCEKProductRoots_Guards(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		report *spb.Report
+		vcek   []byte
+	}{
+		{"v2 report (no CPUID)", &spb.Report{}, []byte{0x30}},
+		{"v3 report without a VCEK", &spb.Report{Cpuid1EaxFms: sienaFms}, nil},
+		{"classifiable v3 (Genoa)", &spb.Report{Cpuid1EaxFms: genoaFms}, []byte("ignored")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			roots, err := vcekProductRoots(tc.report, tc.vcek)
+			if err != nil || roots != nil {
+				t.Fatalf("want (nil, nil); got (%v, %v)", roots, err)
+			}
+		})
+	}
+}
+
+// Genoa-family CPUID_1_EAX values: genoaFms (family 0x19, model 0x11) is
+// classifiable by go-sev-guest; sienaFms (model 0xA0, Zen4c) is not.
+const (
+	genoaFms = uint32(0x00a10f11)
+	sienaFms = uint32(0x00aa0f02)
+)

--- a/attestation/snp/snp_test.go
+++ b/attestation/snp/snp_test.go
@@ -1,11 +1,16 @@
 package snp
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/google/go-sev-guest/kds"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
+	test "github.com/google/go-sev-guest/testing"
+	"github.com/google/go-sev-guest/verify/trust"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 )
@@ -115,3 +120,131 @@ const (
 	genoaFms = uint32(0x00a10f11)
 	sienaFms = uint32(0x00aa0f02)
 )
+
+// TestVCEKProductRoots_GenoaVCEK proves the back-fill resolves an unclassifiable
+// Zen4c CPUID (Siena, 0xA0) to the bundled Genoa roots by reading the product
+// line from the VCEK certificate. The VCEK is minted by go-sev-guest's own
+// test-only chain so the test is offline and deterministic.
+func TestVCEKProductRoots_GenoaVCEK(t *testing.T) {
+	signer, err := test.DefaultTestOnlyCertChain("Genoa", time.Now())
+	if err != nil {
+		t.Fatalf("DefaultTestOnlyCertChain: %v", err)
+	}
+
+	roots, err := vcekProductRoots(&spb.Report{Cpuid1EaxFms: sienaFms}, signer.Vcek.Raw)
+	if err != nil {
+		t.Fatalf("vcekProductRoots: %v", err)
+	}
+
+	// Roots must be keyed under the line go-sev-guest derives for the report
+	// ("Unknown"), and the supplied root must be the bundled Genoa one.
+	key := kds.ProductLineFromFms(sienaFms)
+	if len(roots[key]) != 1 {
+		t.Fatalf("want one root under %q; got %v", key, roots)
+	}
+	genoa, err := trust.GetDefaultRootCerts("Genoa")
+	if err != nil {
+		t.Fatalf("GetDefaultRootCerts(Genoa): %v", err)
+	}
+	if got := roots[key][0]; got.ProductLine != "Genoa" || got.ArkSev != genoa.ArkSev {
+		t.Fatalf("supplied root is not the bundled Genoa root: %+v", got)
+	}
+}
+
+// TestVCEKProductRoots_BadVCEK ensures an unclassifiable report carrying
+// non-certificate VCEK bytes surfaces a parse error instead of silently
+// skipping the back-fill.
+func TestVCEKProductRoots_BadVCEK(t *testing.T) {
+	if _, err := vcekProductRoots(&spb.Report{Cpuid1EaxFms: sienaFms}, []byte("not a certificate")); err == nil {
+		t.Fatal("expected VCEK parse error, got nil")
+	}
+}
+
+// TestValidateOptions covers the VerifyParams -> validate.Options mapping,
+// including the report_data / init_data padding and size limits.
+func TestValidateOptions(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		opts, err := validateOptions(teetypes.VerifyParams{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if opts.VMPL == nil || *opts.VMPL != 0 {
+			t.Errorf("VMPL = %v, want 0", opts.VMPL)
+		}
+		if !opts.GuestPolicy.SMT || !opts.GuestPolicy.MigrateMA || opts.GuestPolicy.Debug {
+			t.Errorf("unexpected default guest policy: %+v", opts.GuestPolicy)
+		}
+		if opts.ReportData != nil || opts.HostData != nil {
+			t.Errorf("expected no report_data/host_data; got %x / %x", opts.ReportData, opts.HostData)
+		}
+	})
+
+	t.Run("report_data padded to 64", func(t *testing.T) {
+		opts, err := validateOptions(teetypes.VerifyParams{ExpectedReportData: []byte{1, 2, 3}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := append([]byte{1, 2, 3}, make([]byte, 61)...)
+		if !bytes.Equal(opts.ReportData, want) {
+			t.Errorf("report_data = %x, want %x", opts.ReportData, want)
+		}
+	})
+
+	t.Run("init_data padded to 32 and debug honored", func(t *testing.T) {
+		opts, err := validateOptions(teetypes.VerifyParams{ExpectedInitDataHash: []byte{9}, AllowDebug: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(opts.HostData) != 32 || opts.HostData[0] != 9 {
+			t.Errorf("host_data = %x, want 9 padded to 32", opts.HostData)
+		}
+		if !opts.GuestPolicy.Debug {
+			t.Error("AllowDebug should set GuestPolicy.Debug")
+		}
+	})
+
+	t.Run("MinTCB mapped", func(t *testing.T) {
+		opts, err := validateOptions(teetypes.VerifyParams{MinTCB: &teetypes.SnpTcb{Bootloader: 1, Tee: 2, Snp: 3, Microcode: 4}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := kds.TCBParts{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}
+		if opts.MinimumTCB != want {
+			t.Errorf("MinimumTCB = %+v, want %+v", opts.MinimumTCB, want)
+		}
+	})
+
+	t.Run("oversize inputs rejected", func(t *testing.T) {
+		if _, err := validateOptions(teetypes.VerifyParams{ExpectedReportData: make([]byte, 65)}); err == nil {
+			t.Error("report_data > 64 should error")
+		}
+		if _, err := validateOptions(teetypes.VerifyParams{ExpectedInitDataHash: make([]byte, 33)}); err == nil {
+			t.Error("init_data_hash > 32 should error")
+		}
+	})
+}
+
+// TestVerifyReport_BindingFlags exercises the report_data / init_data binding
+// reporting on the real Milan fixture: feeding the report's own values back must
+// verify and set the match flags.
+func TestVerifyReport_BindingFlags(t *testing.T) {
+	base, err := VerifyReport(milanReport, milanVcek, teetypes.VerifyParams{}, teetypes.PlatformSNP, MinReportVersionAzure, Options{})
+	if err != nil {
+		t.Fatalf("baseline VerifyReport: %v", err)
+	}
+
+	params := teetypes.VerifyParams{
+		ExpectedReportData:   base.Claims.ReportData,
+		ExpectedInitDataHash: base.Claims.InitData,
+	}
+	res, err := VerifyReport(milanReport, milanVcek, params, teetypes.PlatformSNP, MinReportVersionAzure, Options{})
+	if err != nil {
+		t.Fatalf("VerifyReport with bindings: %v", err)
+	}
+	if res.ReportDataMatch == nil || !*res.ReportDataMatch {
+		t.Errorf("ReportDataMatch = %v, want true", res.ReportDataMatch)
+	}
+	if res.InitDataMatch == nil || !*res.InitDataMatch {
+		t.Errorf("InitDataMatch = %v, want true", res.InitDataMatch)
+	}
+}


### PR DESCRIPTION
go-sev-guest selects its bundled AMD roots by the product line it derives from the report's CPUID. For Zen4c parts (Bergamo/Siena, family 0x19 model 0xA0) that derivation returns "Unknown", so offline root selection fails and bare-metal SNP verification of those parts could not complete.

Replace the stale hardcoded family/model table in productFromReport — whose v3 mapping go-sev-guest ignored and whose v2 path hit its default — with vcekProductRoots, which reads the authoritative product line from the VCEK certificate and supplies the matching bundled roots under the line go-sev-guest derives for the report. This is a single, authoritative product-resolution mechanism rather than two.

The previously skipped Genoa bare-metal test now verifies end to end against a real Bergamo/Siena fixture; a guard-condition test covers the fallback no-ops.

Consolidates and supersedes #8 (bare-report verification, already provided by the snp package; dep bump superseded by v0.15.0) and #9 (VCEK-derived roots, folded in here in cleaner form).

This also improves testing