### PR TITLE
fix(snp): verify Azure v2 HCL reports

### DIFF
--- a/attestation/azsnp/evidence_v1_test.go
+++ b/attestation/azsnp/evidence_v1_test.go
@@ -1,0 +1,36 @@
+package azsnp
+
+import (
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/snp"
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+)
+
+//go:embed testdata/evidence-v1.json
+var evidenceV1Fixture []byte
+
+// TestVerifyEvidence_V1BoundNonce verifies the recorded az-snp evidence whose
+// vTPM quote binds the ASCII nonce "challenge" (mirrors attestation-rs
+// az_snp verify.rs tests). The nonce is compared raw against the quote's
+// extraData — callers pass the anchor unpadded.
+func TestVerifyEvidence_V1BoundNonce(t *testing.T) {
+	var env struct {
+		Evidence json.RawMessage `json:"evidence"`
+	}
+	if err := json.Unmarshal(evidenceV1Fixture, &env); err != nil {
+		t.Fatal(err)
+	}
+	res, err := VerifyEvidence(env.Evidence, teetypes.VerifyParams{ExpectedReportData: []byte("challenge")}, snp.Options{})
+	if err != nil {
+		t.Fatalf("evidence-v1 should verify with its bound nonce: %v", err)
+	}
+	if res.ReportDataMatch == nil || !*res.ReportDataMatch {
+		t.Fatal("report_data_match must be affirmatively true")
+	}
+	if _, err := VerifyEvidence(env.Evidence, teetypes.VerifyParams{ExpectedReportData: []byte("other-nonce")}, snp.Options{}); err == nil {
+		t.Fatal("a different nonce must fail closed")
+	}
+}

--- a/attestation/snp/snp.go
+++ b/attestation/snp/snp.go
@@ -119,7 +119,12 @@ func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, pla
 	// (DisableCertFetching) unless a Getter is supplied for CRL/cert fetching.
 	verifyOpts := sv.DefaultOptions()
 	verifyOpts.CheckRevocations = opts.CheckRevocations
-	verifyOpts.Product = abi.SevProductFromCpuid1Eax(report.GetCpuid1EaxFms())
+	// v2 reports (az-snp) carry no CPUID: leave Product nil (no constraint) so
+	// go-sev-guest derives the line from the V[CL]EK cert and still anchors to
+	// its bundled AMD roots; a forced UNKNOWN product fails its cert check.
+	if fms := report.GetCpuid1EaxFms(); fms != 0 {
+		verifyOpts.Product = abi.SevProductFromCpuid1Eax(fms)
+	}
 	verifyOpts.DisableCertFetching = opts.Getter == nil
 	if opts.Getter != nil {
 		verifyOpts.Getter = opts.Getter
@@ -183,7 +188,11 @@ func validateOptions(params teetypes.VerifyParams) (*validate.Options, error) {
 			Debug:        params.AllowDebug,
 			SingleSocket: false,
 		},
-		VMPL: &vmpl0,
+		// Match attestation-rs, which has no committed==current requirement:
+		// hosts routinely run not-yet-committed firmware (committed < current).
+		// Committed ≤ current is still enforced; MinTCB is the policy floor.
+		PermitProvisionalFirmware: true,
+		VMPL:                      &vmpl0,
 	}
 	if d := params.ExpectedReportData; d != nil {
 		if len(d) > 64 {


### PR DESCRIPTION
Two hardware-layer failures on az-snp evidence, both surfaced once the vTPM nonce gate stopped masking them:

- v2 reports carry no CPUID, but VerifyReport forced a non-nil SEV_PRODUCT_UNKNOWN expectation that go-sev-guest then failed against the VCEK's product name (vcekProductRoots explicitly skips v2). Leave Product nil for CPUID-less reports: go-sev-guest derives the line from the V[CL]EK cert and still anchors to its bundled AMD roots, mirroring attestation-rs's generation fallback. Bare-metal SNP (v3+, CPUID always present) is unaffected.

- PermitProvisionalFirmware is now true: hosts routinely run not-yet-committed firmware, and attestation-rs — the engine the cluster enforces with — has no committed==current check, so the strict default rejected evidence the cluster accepts. committed<=current, cert TCB==reported, and the MinTCB floor remain enforced.~