### PR TITLE
fix(snp): fetch bare-report VCEK from KDS with a Zen4c-aware product …

### DIFF
--- a/attestation/snp/snp.go
+++ b/attestation/snp/snp.go
@@ -8,9 +8,12 @@
 package snp
 
 import (
+	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/google/go-sev-guest/abi"
@@ -22,6 +25,11 @@ import (
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 )
+
+// ErrCollateralUnavailable marks a failed AMD KDS collateral fetch (network /
+// timeout), as opposed to a verification rejection. Callers can errors.Is it to
+// report "collateral unavailable" instead of "attestation invalid".
+var ErrCollateralUnavailable = errors.New("snp: collateral unavailable")
 
 // Report version bounds. Bare-metal SNP requires v3+ (CPUID fields); Azure CVMs
 // emit v2 reports, so az-snp passes MinReportVersionAzure.
@@ -53,8 +61,8 @@ type Options struct {
 	// CheckRevocations fetches AMD CRLs and checks the VCEK/ASK for revocation.
 	// Requires network (Getter). Off by default → offline verification.
 	CheckRevocations bool
-	// Getter fetches collateral (CRLs, missing certs). Defaults to none
-	// (offline); set for revocation/cert fetching.
+	// Getter fetches collateral: the VCEK for a bare report (see fetchVCEK) and
+	// CRLs. Defaults to none → fully offline, VCEK must be supplied inline.
 	Getter trust.HTTPSGetter
 }
 
@@ -81,6 +89,16 @@ func VerifyEvidence(ev SnpEvidence, params teetypes.VerifyParams, opts Options) 
 // (go-sev-guest validate), then extracts claims. minVersion lets az-snp accept
 // v2 reports while bare-metal requires v3. Shared by the snp and azsnp packages.
 func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, platform teetypes.PlatformType, minVersion uint32, opts Options) (*teetypes.VerificationResult, error) {
+	return VerifyReportContext(context.Background(), reportBytes, vcekDER, params, platform, minVersion, opts)
+}
+
+// VerifyReportContext behaves like VerifyReport and additionally: when vcekDER
+// is empty, the report is VCEK-signed, and opts.Getter is set, it fetches the
+// VCEK from AMD KDS itself — resolving the product line from the report's CPUID
+// including Zen4c (Bergamo/Siena), which go-sev-guest maps to "Unknown" (see
+// kdsProductLine). ctx bounds the fetch; chain verification itself is always
+// offline against bundled AMD roots.
+func VerifyReportContext(ctx context.Context, reportBytes, vcekDER []byte, params teetypes.VerifyParams, platform teetypes.PlatformType, minVersion uint32, opts Options) (*teetypes.VerificationResult, error) {
 	report, err := abi.ReportToProto(reportBytes)
 	if err != nil {
 		return nil, fmt.Errorf("snp: parsing report: %w", err)
@@ -97,6 +115,11 @@ func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, pla
 	signer, err := abi.ParseSignerInfo(report.GetSignerInfo())
 	if err != nil {
 		return nil, fmt.Errorf("snp: parsing signer info: %w", err)
+	}
+	if len(vcekDER) == 0 && signer.SigningKey == abi.VcekReportSigner && opts.Getter != nil {
+		if vcekDER, err = fetchVCEK(ctx, report, opts.Getter); err != nil {
+			return nil, err
+		}
 	}
 	certChain := &spb.CertificateChain{}
 	switch signer.SigningKey {
@@ -115,8 +138,11 @@ func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, pla
 	// Hardware verification: report signature + ARK→ASK→VCEK (or ARK→ASVK→VLEK)
 	// chain + VEK TCB OID cross-validation, against go-sev-guest's bundled AMD
 	// roots. The product (Milan/Genoa/Turin) selects which embedded roots to use;
-	// we resolve it from the report so verification stays offline
-	// (DisableCertFetching) unless a Getter is supplied for CRL/cert fetching.
+	// we resolve it from the report. Chain verification is always offline
+	// (DisableCertFetching): go-sev-guest's own KDS path derives the product line
+	// from CPUID alone and hangs on parts it cannot classify (Zen4c → "Unknown"
+	// URLs); the VCEK is already in hand (inline or fetchVCEK) and ASK/ARK come
+	// from bundled roots. The Getter is kept for CRL fetching only.
 	verifyOpts := sv.DefaultOptions()
 	verifyOpts.CheckRevocations = opts.CheckRevocations
 	// v2 reports (az-snp) carry no CPUID: leave Product nil (no constraint) so
@@ -125,7 +151,7 @@ func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, pla
 	if fms := report.GetCpuid1EaxFms(); fms != 0 {
 		verifyOpts.Product = abi.SevProductFromCpuid1Eax(fms)
 	}
-	verifyOpts.DisableCertFetching = opts.Getter == nil
+	verifyOpts.DisableCertFetching = true
 	if opts.Getter != nil {
 		verifyOpts.Getter = opts.Getter
 	}
@@ -144,7 +170,7 @@ func VerifyReport(reportBytes, vcekDER []byte, params teetypes.VerifyParams, pla
 			verifyOpts.TrustedRoots = roots
 		}
 	}
-	if err := sv.SnpAttestation(attestation, verifyOpts); err != nil {
+	if err := sv.SnpAttestationContext(ctx, attestation, verifyOpts); err != nil {
 		return nil, fmt.Errorf("snp: hardware verification failed: %w", err)
 	}
 
@@ -232,6 +258,45 @@ func pad(b []byte, n int) []byte {
 	out := make([]byte, n)
 	copy(out, b)
 	return out
+}
+
+// kdsProductLine maps a v3+ report's CPUID_1_EAX to the AMD KDS product line
+// its collateral is served under. go-sev-guest's own table covers Milan, Genoa,
+// and Turin; Zen4c (Bergamo/Siena, family 0x19 models 0xA0–0xAF) it maps to
+// "Unknown", but KDS serves those parts' collateral under Genoa.
+func kdsProductLine(fms uint32) (string, error) {
+	if abi.SevProductFromCpuid1Eax(fms).GetName() != spb.SevProduct_SEV_PRODUCT_UNKNOWN {
+		return kds.ProductLineFromFms(fms), nil
+	}
+	family, model, _ := abi.FmsFromCpuid1Eax(fms)
+	if family == 0x19 && model >= 0xA0 && model <= 0xAF {
+		return "Genoa", nil
+	}
+	return "", fmt.Errorf("snp: no KDS product line known for CPUID family %#x model %#x", family, model)
+}
+
+// fetchVCEK downloads a VCEK-signed report's VCEK from AMD KDS via getter,
+// bounded by ctx and the getter's own retry policy. Network failures wrap
+// ErrCollateralUnavailable; a report whose VCEK URL cannot be derived (no
+// CPUID, zeroed CHIP_ID) is a plain error — refetching cannot help.
+func fetchVCEK(ctx context.Context, report *spb.Report, getter trust.HTTPSGetter) ([]byte, error) {
+	fms := report.GetCpuid1EaxFms()
+	if fms == 0 {
+		return nil, fmt.Errorf("snp: report carries no CPUID product info; cannot derive its KDS VCEK URL (supply the VCEK inline)")
+	}
+	productLine, err := kdsProductLine(fms)
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.Trim(report.GetChipId(), "\x00")) == 0 {
+		return nil, fmt.Errorf("snp: report has an all-zero CHIP_ID (MaskChipKey?); cannot derive its KDS VCEK URL (supply the VCEK inline)")
+	}
+	url := kds.VCEKCertURL(productLine, report.GetChipId(), kds.TCBVersion(report.GetReportedTcb()))
+	der, err := trust.GetWith(ctx, getter, url)
+	if err != nil {
+		return nil, fmt.Errorf("%w: GET %s: %w", ErrCollateralUnavailable, url, err)
+	}
+	return der, nil
 }
 
 // vcekProductRoots back-fills trusted roots for parts go-sev-guest cannot

--- a/attestation/snp/snp_test.go
+++ b/attestation/snp/snp_test.go
@@ -2,12 +2,16 @@ package snp
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/google/go-sev-guest/abi"
 	"github.com/google/go-sev-guest/kds"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	test "github.com/google/go-sev-guest/testing"
@@ -91,6 +95,123 @@ func TestVerifyEvidence_BareMetalEnvelope(t *testing.T) {
 	}
 	if len(res.Claims.LaunchDigest) != 96 || res.Claims.TCB.Type != "Snp" {
 		t.Fatalf("unexpected claims: %+v", res.Claims)
+	}
+}
+
+// genoaFixture returns the raw report and paired VCEK DER from the live
+// Zen4c/Genoa evidence fixture.
+func genoaFixture(t *testing.T) (report, vcek []byte) {
+	t.Helper()
+	var env struct {
+		Evidence json.RawMessage `json:"evidence"`
+	}
+	if err := json.Unmarshal(genoaEvidence, &env); err != nil {
+		t.Fatal(err)
+	}
+	var ev SnpEvidence
+	if err := json.Unmarshal(env.Evidence, &ev); err != nil {
+		t.Fatal(err)
+	}
+	report, err := base64.StdEncoding.DecodeString(ev.AttestationReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vcek, err = base64.StdEncoding.DecodeString(ev.CertChain.Vcek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return report, vcek
+}
+
+// TestVerifyReportContext_FetchesZen4cVCEKFromGenoa is the regression test for
+// the Siena `c8s verify` hang: a bare (VCEK-less) Zen4c report must resolve to
+// the Genoa KDS URL and verify end to end. The fake getter serves the fixture's
+// real VCEK under exactly that URL and 404s anything else, so a wrong product
+// line (go-sev-guest derives "Unknown") fails the test.
+func TestVerifyReportContext_FetchesZen4cVCEKFromGenoa(t *testing.T) {
+	report, vcek := genoaFixture(t)
+	rp, err := abi.ReportToProto(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	url := kds.VCEKCertURL("Genoa", rp.GetChipId(), kds.TCBVersion(rp.GetReportedTcb()))
+	getter := test.SimpleGetter(map[string][]byte{url: vcek})
+
+	res, err := VerifyReportContext(context.Background(), report, nil, teetypes.VerifyParams{},
+		teetypes.PlatformSNP, MinReportVersion, Options{Getter: getter})
+	if err != nil {
+		t.Fatalf("VerifyReportContext with KDS fetch: %v", err)
+	}
+	if !res.SignatureValid || len(res.Claims.LaunchDigest) != 96 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+// TestVerifyReportContext_KDSFailureIsCollateralError: a failing fetch must
+// surface ErrCollateralUnavailable (so callers report availability, not a
+// security verdict) and must return promptly when the context is cancelled
+// even with a retrying getter — the original bug retried unbounded.
+func TestVerifyReportContext_KDSFailureIsCollateralError(t *testing.T) {
+	report, _ := genoaFixture(t)
+
+	t.Run("fetch error wraps sentinel", func(t *testing.T) {
+		_, err := VerifyReportContext(context.Background(), report, nil, teetypes.VerifyParams{},
+			teetypes.PlatformSNP, MinReportVersion, Options{Getter: test.SimpleGetter(nil)})
+		if !errors.Is(err, ErrCollateralUnavailable) {
+			t.Fatalf("want ErrCollateralUnavailable, got %v", err)
+		}
+	})
+
+	t.Run("cancelled ctx bounds a retrying getter", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		getter := &trust.RetryHTTPSGetter{MaxRetryDelay: time.Minute, Getter: test.SimpleGetter(nil)}
+		start := time.Now()
+		_, err := VerifyReportContext(ctx, report, nil, teetypes.VerifyParams{},
+			teetypes.PlatformSNP, MinReportVersion, Options{Getter: getter})
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Fatalf("cancelled ctx took %v, want prompt return", elapsed)
+		}
+		if !errors.Is(err, ErrCollateralUnavailable) {
+			t.Fatalf("want ErrCollateralUnavailable, got %v", err)
+		}
+	})
+}
+
+// TestVerifyReport_MissingVCEKWithoutGetter pins the offline contract: no VCEK
+// and no getter is an error, never an implicit network fetch.
+func TestVerifyReport_MissingVCEKWithoutGetter(t *testing.T) {
+	report, _ := genoaFixture(t)
+	if _, err := VerifyReport(report, nil, teetypes.VerifyParams{}, teetypes.PlatformSNP, MinReportVersion, Options{}); err == nil {
+		t.Fatal("missing VCEK with no getter must fail")
+	}
+}
+
+func TestKDSProductLine(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fms  uint32
+		want string // "" = expect an error
+	}{
+		{"Siena/Bergamo (Zen4c, model 0xA0) → Genoa", sienaFms, "Genoa"},
+		{"Zen4c upper bound (family 0x19, model 0xAF)", 0x00aa0ff0, "Genoa"},
+		{"Genoa proper (go-sev-guest's own table)", genoaFms, "Genoa"},
+		{"Milan proper", 0x00a00f11, "Milan"},
+		{"unknown family 0x1B", 0x00c00f00, ""},
+		{"family 0x19 below Zen4c range (model 0x90)", 0x00a90f00, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := kdsProductLine(tc.fms)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("kdsProductLine(%#x) = (%q, %v), want %q", tc.fms, got, err, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
…line

A bare (VCEK-less) report was handed to go-sev-guest with cert fetching enabled, and go-sev-guest derives the KDS product line from CPUID alone. Zen4c parts (Bergamo/Siena, family 0x19 models 0xA0-0xAF) map to "Unknown" in its table, so it requested /vcek/v1/Unknown/... and retried the 404s for its whole 2-minute getter budget, unbounded by any caller deadline — `c8s verify` hung on Siena hosts (c8s docs/pitfalls.md, "Zen4c KDS product line").