### PR TITLE
fix(tpm): require PCR[8] in the signed selection before trusting init-data

### DIFF
--- a/attestation/azsnp/azsnp.go
+++ b/attestation/azsnp/azsnp.go
@@ -201,7 +201,7 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts snp.Options
 	if err := tpmcommon.VerifyHCLVarDataBinding(hw.Claims.ReportData, d.hcl.VarData); err != nil {
 		return nil, err
 	}
-	initDataMatch, err := tpmcommon.CheckInitData(d.quote.PCRs, params.ExpectedInitDataHash)
+	initDataMatch, err := tpmcommon.CheckInitData(d.quote.Message, d.quote.PCRs, params.ExpectedInitDataHash)
 	if err != nil {
 		return nil, err
 	}

--- a/attestation/aztdx/aztdx.go
+++ b/attestation/aztdx/aztdx.go
@@ -96,7 +96,7 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts tdx.Options
 	if err := tpmcommon.VerifyHCLVarDataBinding(hw.Claims.ReportData, hcl.VarData); err != nil {
 		return nil, err
 	}
-	initDataMatch, err := tpmcommon.CheckInitData(quote.PCRs, params.ExpectedInitDataHash)
+	initDataMatch, err := tpmcommon.CheckInitData(quote.Message, quote.PCRs, params.ExpectedInitDataHash)
 	if err != nil {
 		return nil, err
 	}

--- a/attestation/tpmcommon/tpmcommon.go
+++ b/attestation/tpmcommon/tpmcommon.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
@@ -378,12 +379,30 @@ func VerifyTPMPCRs(message []byte, pcrs [][]byte) error {
 
 // CheckInitData verifies PCR[8] == SHA-256(zeros_32 || expected), the TPM
 // extend of the init-data hash. Returns nil when expected is nil.
-func CheckInitData(pcrs [][]byte, expected []byte) (*bool, error) {
+//
+// SECURITY: pcrs is attacker-controlled data carried alongside the quote, but
+// only the PCRs named in the quote's signed pcrSelect are covered by the
+// AK-signed pcrDigest (VerifyTPMPCRs enforces that digest). Reading pcrs[8] is
+// therefore only sound if index 8 is in that signed selection; otherwise a
+// caller could issue a real quote whose selection excludes PCR 8 and then append
+// a forged pcrs[8] = SHA-256(0^32 || attacker_init_data) that the signature never
+// covered, spoofing InitDataMatch=true. So we re-derive the signed selection from
+// the (already signature-verified) quote message and require index 8 to be
+// present before trusting pcrs[8]. Callers MUST verify the quote signature and
+// call VerifyTPMPCRs before this.
+func CheckInitData(message []byte, pcrs [][]byte, expected []byte) (*bool, error) {
 	if expected == nil {
 		return nil, nil
 	}
 	if len(expected) != 32 {
 		return nil, fmt.Errorf("expected_init_data_hash must be 32 bytes, got %d", len(expected))
+	}
+	selected, _, err := parseQuoteInfo(message)
+	if err != nil {
+		return nil, fmt.Errorf("init_data check: parse quote selection: %w", err)
+	}
+	if !slices.Contains(selected, 8) {
+		return nil, fmt.Errorf("init_data check needs PCR[8] but it is not in the quote's signed PCR selection (would be unauthenticated)")
 	}
 	if len(pcrs) <= 8 {
 		return nil, fmt.Errorf("init_data check needs PCR[8] but only %d PCRs present", len(pcrs))

--- a/attestation/tpmcommon/tpmcommon_test.go
+++ b/attestation/tpmcommon/tpmcommon_test.go
@@ -129,7 +129,8 @@ func TestCheckReportDataAndInitData(t *testing.T) {
 	if m, err := CheckReportData(msg, nonce); err != nil || m == nil || !*m {
 		t.Fatalf("matching nonce → true; got %v %v", m, err)
 	}
-	// PCR[8] init-data extend.
+	// PCR[8] init-data extend. The message must select PCR 8 (bitmap byte 1,
+	// bit 0), else CheckInitData rejects it as unauthenticated (see below).
 	pcrs := zeroPCRs()
 	hash := make([]byte, 32)
 	for i := range hash {
@@ -139,11 +140,41 @@ func TestCheckReportDataAndInitData(t *testing.T) {
 	h.Write(make([]byte, 32))
 	h.Write(hash)
 	pcrs[8] = h.Sum(nil)
-	if m, err := CheckInitData(pcrs, hash); err != nil || m == nil || !*m {
+	sel8 := []byte{3, 0xFF, 0xFF, 0xFF} // PCRs 0-23 selected → index 8 covered
+	msg8 := buildTPMSAttest(nonce, sel8, make([]byte, 32))
+	if m, err := CheckInitData(msg8, pcrs, hash); err != nil || m == nil || !*m {
 		t.Fatalf("init-data extend should match: %v %v", m, err)
 	}
-	if _, err := CheckInitData(pcrs, make([]byte, 32)); err == nil {
+	if _, err := CheckInitData(msg8, pcrs, make([]byte, 32)); err == nil {
 		t.Fatal("wrong init-data should fail")
+	}
+}
+
+// TestCheckInitData_RejectsUnselectedPCR8 is a regression PoC: a quote whose
+// signed PCR selection EXCLUDES index 8, plus a forged pcrs[8], must be rejected.
+// Before the fix, CheckInitData read pcrs[8] unconditionally, so an attacker on a
+// genuine CVM could issue a real AK-signed quote selecting only PCRs 0-7 and
+// append pcrs[8] = SHA-256(0^32 || attacker_init_data) to spoof InitDataMatch.
+func TestCheckInitData_RejectsUnselectedPCR8(t *testing.T) {
+	nonce := []byte("nonce-value")
+	attackerInitData := make([]byte, 32)
+	for i := range attackerInitData {
+		attackerInitData[i] = 0xCC
+	}
+	// Forge pcrs[8] to the value the attacker wants matched.
+	pcrs := zeroPCRs()
+	h := sha256.New()
+	h.Write(make([]byte, 32))
+	h.Write(attackerInitData)
+	pcrs[8] = h.Sum(nil)
+
+	// Selection covers only PCRs 0-7 (byte 1 = 0xFF, byte 2/3 = 0x00) — index 8
+	// is NOT in the signed selection, so pcrs[8] is unauthenticated.
+	selNo8 := []byte{3, 0xFF, 0x00, 0x00}
+	msgNo8 := buildTPMSAttest(nonce, selNo8, make([]byte, 32))
+
+	if _, err := CheckInitData(msgNo8, pcrs, attackerInitData); err == nil {
+		t.Fatal("forged pcrs[8] with PCR 8 outside the signed selection must be rejected")
 	}
 }
 


### PR DESCRIPTION
`CheckInitData` read `pcrs[8]` unconditionally, but `pcrs` is attacker-controlled data carried alongside the quote — only the PCRs named in the quote's signed `pcrSelect` are covered by the AK-signed `pcrDigest` (enforced by `VerifyTPMPCRs`). 

An attacker on a genuine Azure CVM could issue a real AK-signed TPM2_Quote whose selection excludes PCR 8, then append a forged `pcrs[8] = SHA-256(0^32 || attacker_init_data)`. `VerifyTPMPCRs` (which only checks selected PCRs) passes, and `CheckInitData` then returned `InitDataMatch=true` for init-data the TEE never measured, a spoof of workload/config identity for any consumer that pins `expected_init_data_hash` on az-snp/az-tdx.

Re-derive the signed selection from the (already signature-verified) quote message and require index 8 to be present before reading `pcrs[8]`. `CheckInitData` now takes the quote message; callers (azsnp, aztdx) pass it. Adds a regression PoC test (selection excludes PCR 8 + forged pcrs[8] must be rejected).

Note: c8s itself does not currently pin init-data, so this is not reachable through c8s's own wiring today, it hardens attestation-go for any consumer that does. 

The general rule: every PCR consumed for a decision must be inside the quote's signed selection.