### PR TITLE
feat(aztdx): add Verify/Result parity API with VerifyVTPMFreshness

### DIFF
--- a/attestation/azsnp/azsnp.go
+++ b/attestation/azsnp/azsnp.go
@@ -201,7 +201,7 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts snp.Options
 	if err := tpmcommon.VerifyHCLVarDataBinding(hw.Claims.ReportData, d.hcl.VarData); err != nil {
 		return nil, err
 	}
-	initDataMatch, err := tpmcommon.CheckInitData(d.quote.PCRs, params.ExpectedInitDataHash)
+	initDataMatch, err := tpmcommon.CheckInitData(d.quote.Message, d.quote.PCRs, params.ExpectedInitDataHash)
 	if err != nil {
 		return nil, err
 	}

--- a/attestation/aztdx/aztdx.go
+++ b/attestation/aztdx/aztdx.go
@@ -27,6 +27,119 @@ type azTdxEvidence struct {
 	TPMQuote  *tpmcommon.RawTPMQuote `json:"tpm_quote"`
 }
 
+// envelope is the self-describing {platform, evidence} wrapper.
+type envelope struct {
+	Platform string          `json:"platform"`
+	Evidence json.RawMessage `json:"evidence"`
+}
+
+// --- Back-compat lightweight API (mirrors azsnp; used by TEErminator's Flow A
+// policy layer so one tls-header remote can be backed by SNP or TDX) ---
+
+// Result is the lightweight result of az-tdx hardware verification: the launch
+// measurement (MRTD), the TD report's report_data, the HCL var_data (vTPM AK
+// material), and the decoded vTPM quote. Use VerifyVTPMFreshness to bind a
+// nonce. Mirrors azsnp.Result so callers can treat both Azure vTPM platforms
+// uniformly.
+type Result struct {
+	Measurement string
+	ReportData  []byte
+	VarData     []byte
+	TPMQuote    *tpmcommon.TPMQuote
+}
+
+// Verify verifies the TD quote inside an az-tdx envelope (Intel DCAP signature +
+// chain via the tdx package) and returns the MRTD launch measurement, the TD
+// report_data, the HCL var_data, and the decoded vTPM quote. It does not enforce
+// freshness; use Result.VerifyVTPMFreshness. Mirrors azsnp.Verify.
+func Verify(raw []byte) (*Result, error) {
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("parsing az-tdx envelope: %w", err)
+	}
+	if env.Platform != string(teetypes.PlatformAzTDX) {
+		return nil, fmt.Errorf("unexpected platform %q, want %q", env.Platform, teetypes.PlatformAzTDX)
+	}
+	var ev azTdxEvidence
+	if err := json.Unmarshal(env.Evidence, &ev); err != nil {
+		return nil, fmt.Errorf("parsing az-tdx evidence: %w", err)
+	}
+	hcl, tdQuoteBytes, quote, err := decode(ev)
+	if err != nil {
+		return nil, err
+	}
+	hw, err := tdx.VerifyQuoteBytes(tdQuoteBytes, teetypes.VerifyParams{}, teetypes.PlatformAzTDX, tdx.Options{})
+	if err != nil {
+		return nil, err
+	}
+	return &Result{
+		Measurement: hw.Claims.LaunchDigest,
+		ReportData:  hw.Claims.ReportData,
+		VarData:     hcl.VarData,
+		TPMQuote:    quote,
+	}, nil
+}
+
+// VerifyAttestation reports only whether the az-tdx TD quote is valid.
+func VerifyAttestation(raw []byte) error {
+	_, err := Verify(raw)
+	return err
+}
+
+// VerifyVTPMFreshness verifies the az-tdx vTPM trust chain binds nonce:
+// TD report_data == SHA-256(var_data) → AK pub → AK-signed quote → quote
+// extraData == nonce. PCR digest integrity is checked too. Mirrors
+// azsnp.Result.VerifyVTPMFreshness — the tpmcommon chain is platform-agnostic.
+func (r *Result) VerifyVTPMFreshness(nonce []byte) error {
+	if r.TPMQuote == nil {
+		return fmt.Errorf("evidence carries no vTPM quote")
+	}
+	if len(r.VarData) == 0 {
+		return fmt.Errorf("HCL report carries no var_data to bind the vTPM AK")
+	}
+	if err := tpmcommon.VerifyHCLVarDataBinding(r.ReportData, r.VarData); err != nil {
+		return err
+	}
+	if err := tpmcommon.VerifyTPMSignature(r.TPMQuote.Signature, r.TPMQuote.Message, r.VarData); err != nil {
+		return err
+	}
+	if err := tpmcommon.VerifyTPMPCRs(r.TPMQuote.Message, r.TPMQuote.PCRs); err != nil {
+		return err
+	}
+	return tpmcommon.VerifyTPMNonce(r.TPMQuote.Message, nonce)
+}
+
+// decode pulls the HCL report, raw TD quote bytes, and decoded vTPM quote out of
+// an az-tdx evidence payload, enforcing the required tpm_quote and TDX report
+// type. Shared by Verify and VerifyEvidence.
+func decode(ev azTdxEvidence) (*tpmcommon.HCLReport, []byte, *tpmcommon.TPMQuote, error) {
+	if ev.TPMQuote == nil {
+		return nil, nil, nil, fmt.Errorf("az-tdx evidence is missing the required tpm_quote")
+	}
+	hclBytes, err := tpmcommon.DecodeBase64URL(ev.HCLReport)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("decoding hcl_report: %w", err)
+	}
+	hcl, err := tpmcommon.ParseHCLReport(hclBytes)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if hcl.ReportType != tpmcommon.HCLReportTypeTDX {
+		return nil, nil, nil, fmt.Errorf("HCL report_type is %d (expected %d for TDX)", hcl.ReportType, tpmcommon.HCLReportTypeTDX)
+	}
+	tdQuoteBytes, err := tpmcommon.DecodeBase64URL(ev.TDQuote)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("decoding td_quote: %w", err)
+	}
+	quote, err := tpmcommon.DecodeTPMQuote(ev.TPMQuote)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("decoding tpm_quote: %w", err)
+	}
+	return hcl, tdQuoteBytes, quote, nil
+}
+
+// --- Unified API (used by the dispatcher) ---
+
 // VerifyEvidence verifies the inner az-tdx evidence payload end to end against
 // params: the vTPM trust chain, the Intel TDX DCAP quote, the var_data binding,
 // and (when requested) nonce freshness and init-data. opts tunes the DCAP layer
@@ -40,28 +153,10 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts tdx.Options
 	if ev.Version != 1 {
 		return nil, fmt.Errorf("unsupported az-tdx evidence version: %d", ev.Version)
 	}
-	if ev.TPMQuote == nil {
-		return nil, fmt.Errorf("az-tdx evidence is missing the required tpm_quote")
-	}
 
-	hclBytes, err := tpmcommon.DecodeBase64URL(ev.HCLReport)
-	if err != nil {
-		return nil, fmt.Errorf("decoding hcl_report: %w", err)
-	}
-	hcl, err := tpmcommon.ParseHCLReport(hclBytes)
+	hcl, tdQuoteBytes, quote, err := decode(ev)
 	if err != nil {
 		return nil, err
-	}
-	if hcl.ReportType != tpmcommon.HCLReportTypeTDX {
-		return nil, fmt.Errorf("HCL report_type is %d (expected %d for TDX)", hcl.ReportType, tpmcommon.HCLReportTypeTDX)
-	}
-	tdQuoteBytes, err := tpmcommon.DecodeBase64URL(ev.TDQuote)
-	if err != nil {
-		return nil, fmt.Errorf("decoding td_quote: %w", err)
-	}
-	quote, err := tpmcommon.DecodeTPMQuote(ev.TPMQuote)
-	if err != nil {
-		return nil, fmt.Errorf("decoding tpm_quote: %w", err)
 	}
 
 	// TPM layer: the AK (from var_data) signs the quote; the quote's nonce and

--- a/attestation/aztdx/aztdx.go
+++ b/attestation/aztdx/aztdx.go
@@ -96,7 +96,7 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts tdx.Options
 	if err := tpmcommon.VerifyHCLVarDataBinding(hw.Claims.ReportData, hcl.VarData); err != nil {
 		return nil, err
 	}
-	initDataMatch, err := tpmcommon.CheckInitData(quote.PCRs, params.ExpectedInitDataHash)
+	initDataMatch, err := tpmcommon.CheckInitData(quote.Message, quote.PCRs, params.ExpectedInitDataHash)
 	if err != nil {
 		return nil, err
 	}

--- a/attestation/aztdx/aztdx_test.go
+++ b/attestation/aztdx/aztdx_test.go
@@ -48,3 +48,30 @@ func TestVerifyEvidence_Errors(t *testing.T) {
 		t.Fatal("bad version should fail")
 	}
 }
+
+// TestVerify_LightweightAPI exercises the back-compat Verify/Result surface that
+// TEErminator's Flow A consumes: it takes the full {platform, evidence} envelope,
+// verifies the TD quote, and exposes the MRTD + a nonce-binding freshness check.
+func TestVerify_LightweightAPI(t *testing.T) {
+	res, err := Verify(azTdxFixture)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if res.Measurement == "" {
+		t.Fatal("expected an MRTD launch measurement")
+	}
+	if len(res.ReportData) == 0 || len(res.VarData) == 0 || res.TPMQuote == nil {
+		t.Fatalf("incomplete result: %+v", res)
+	}
+
+	// A fresh (unbound) nonce must fail closed: the recorded quote's extraData
+	// binds a different value.
+	if err := res.VerifyVTPMFreshness(make([]byte, 32)); err == nil {
+		t.Fatal("fresh nonce must be rejected on recorded evidence")
+	}
+
+	// A platform-tagged non-TDX envelope is rejected by the envelope guard.
+	if _, err := Verify([]byte(`{"platform":"az-snp","evidence":{}}`)); err == nil {
+		t.Fatal("az-snp envelope must be rejected by aztdx.Verify")
+	}
+}

--- a/attestation/tpmcommon/tpmcommon.go
+++ b/attestation/tpmcommon/tpmcommon.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
@@ -378,12 +379,30 @@ func VerifyTPMPCRs(message []byte, pcrs [][]byte) error {
 
 // CheckInitData verifies PCR[8] == SHA-256(zeros_32 || expected), the TPM
 // extend of the init-data hash. Returns nil when expected is nil.
-func CheckInitData(pcrs [][]byte, expected []byte) (*bool, error) {
+//
+// SECURITY: pcrs is attacker-controlled data carried alongside the quote, but
+// only the PCRs named in the quote's signed pcrSelect are covered by the
+// AK-signed pcrDigest (VerifyTPMPCRs enforces that digest). Reading pcrs[8] is
+// therefore only sound if index 8 is in that signed selection; otherwise a
+// caller could issue a real quote whose selection excludes PCR 8 and then append
+// a forged pcrs[8] = SHA-256(0^32 || attacker_init_data) that the signature never
+// covered, spoofing InitDataMatch=true. So we re-derive the signed selection from
+// the (already signature-verified) quote message and require index 8 to be
+// present before trusting pcrs[8]. Callers MUST verify the quote signature and
+// call VerifyTPMPCRs before this.
+func CheckInitData(message []byte, pcrs [][]byte, expected []byte) (*bool, error) {
 	if expected == nil {
 		return nil, nil
 	}
 	if len(expected) != 32 {
 		return nil, fmt.Errorf("expected_init_data_hash must be 32 bytes, got %d", len(expected))
+	}
+	selected, _, err := parseQuoteInfo(message)
+	if err != nil {
+		return nil, fmt.Errorf("init_data check: parse quote selection: %w", err)
+	}
+	if !slices.Contains(selected, 8) {
+		return nil, fmt.Errorf("init_data check needs PCR[8] but it is not in the quote's signed PCR selection (would be unauthenticated)")
 	}
 	if len(pcrs) <= 8 {
 		return nil, fmt.Errorf("init_data check needs PCR[8] but only %d PCRs present", len(pcrs))

--- a/attestation/tpmcommon/tpmcommon_test.go
+++ b/attestation/tpmcommon/tpmcommon_test.go
@@ -129,7 +129,8 @@ func TestCheckReportDataAndInitData(t *testing.T) {
 	if m, err := CheckReportData(msg, nonce); err != nil || m == nil || !*m {
 		t.Fatalf("matching nonce → true; got %v %v", m, err)
 	}
-	// PCR[8] init-data extend.
+	// PCR[8] init-data extend. The message must select PCR 8 (bitmap byte 1,
+	// bit 0), else CheckInitData rejects it as unauthenticated (see below).
 	pcrs := zeroPCRs()
 	hash := make([]byte, 32)
 	for i := range hash {
@@ -139,11 +140,41 @@ func TestCheckReportDataAndInitData(t *testing.T) {
 	h.Write(make([]byte, 32))
 	h.Write(hash)
 	pcrs[8] = h.Sum(nil)
-	if m, err := CheckInitData(pcrs, hash); err != nil || m == nil || !*m {
+	sel8 := []byte{3, 0xFF, 0xFF, 0xFF} // PCRs 0-23 selected → index 8 covered
+	msg8 := buildTPMSAttest(nonce, sel8, make([]byte, 32))
+	if m, err := CheckInitData(msg8, pcrs, hash); err != nil || m == nil || !*m {
 		t.Fatalf("init-data extend should match: %v %v", m, err)
 	}
-	if _, err := CheckInitData(pcrs, make([]byte, 32)); err == nil {
+	if _, err := CheckInitData(msg8, pcrs, make([]byte, 32)); err == nil {
 		t.Fatal("wrong init-data should fail")
+	}
+}
+
+// TestCheckInitData_RejectsUnselectedPCR8 is a regression PoC: a quote whose
+// signed PCR selection EXCLUDES index 8, plus a forged pcrs[8], must be rejected.
+// Before the fix, CheckInitData read pcrs[8] unconditionally, so an attacker on a
+// genuine CVM could issue a real AK-signed quote selecting only PCRs 0-7 and
+// append pcrs[8] = SHA-256(0^32 || attacker_init_data) to spoof InitDataMatch.
+func TestCheckInitData_RejectsUnselectedPCR8(t *testing.T) {
+	nonce := []byte("nonce-value")
+	attackerInitData := make([]byte, 32)
+	for i := range attackerInitData {
+		attackerInitData[i] = 0xCC
+	}
+	// Forge pcrs[8] to the value the attacker wants matched.
+	pcrs := zeroPCRs()
+	h := sha256.New()
+	h.Write(make([]byte, 32))
+	h.Write(attackerInitData)
+	pcrs[8] = h.Sum(nil)
+
+	// Selection covers only PCRs 0-7 (byte 1 = 0xFF, byte 2/3 = 0x00) — index 8
+	// is NOT in the signed selection, so pcrs[8] is unauthenticated.
+	selNo8 := []byte{3, 0xFF, 0x00, 0x00}
+	msgNo8 := buildTPMSAttest(nonce, selNo8, make([]byte, 32))
+
+	if _, err := CheckInitData(msgNo8, pcrs, attackerInitData); err == nil {
+		t.Fatal("forged pcrs[8] with PCR 8 outside the signed selection must be rejected")
 	}
 }
 


### PR DESCRIPTION
## Summary

`azsnp` exposes a lightweight `Verify(raw) -> Result` surface with a `VerifyVTPMFreshness(nonce)` method that TEErminator's Flow A / Flow B policy layer consumes to bind a per-request nonce through the vTPM quote. `aztdx` only had the unified `VerifyEvidence` path, so a consumer could not verify an `az-tdx` `{platform, evidence}` envelope and bind freshness the same way — TEErminator therefore supported only SNP.

This adds the mirror API to `aztdx`. It does **not** overlap PR #12 (which added VLEK/revocation reachability and `ExpectedLaunchDigest`/RTMR pinning to the *unified* path); the base `aztdx.go` had no `Verify`/`Result`/`VerifyVTPMFreshness`.

## Changes

- `Verify(raw)` parses the envelope, verifies the Intel DCAP TD quote via the `tdx` package, and returns a `Result` exposing the MRTD launch measurement, the TD `report_data`, the HCL `var_data`, and the decoded vTPM quote — mirroring `azsnp.Verify` 1:1.
- `Result.VerifyVTPMFreshness(nonce)` reuses the platform-agnostic `tpmcommon` chain (`report_data -> AK -> AK-signed quote -> extraData == nonce`).
- `VerifyAttestation(raw)` convenience, and a shared `decode` helper that removes the duplication between `Verify` and `VerifyEvidence`.

## Testing

- `go test ./attestation/aztdx/...` green, incl. a new test for `Verify` / `VerifyVTPMFreshness` (positive + fail-closed on an unbound nonce + wrong-platform envelope).
- Verified against a live `Standard_DC4es_v6` (Intel TDX) Azure CVM: real vTPM evidence verifies through `Verify` + `VerifyVTPMFreshness` and fails closed on an unbound nonce.

## Base

Stacked on `fix/init-data-pcr8-selection-coverage`; retarget to `main` once that merges.