### PR TITLE
Remove the lightweight Verify/Result API from azsnp and aztdx

### DIFF
--- a/attestation/azsnp/azsnp.go
+++ b/attestation/azsnp/azsnp.go
@@ -30,12 +30,6 @@ type azSnpEvidence struct {
 	TPMQuote  *tpmcommon.RawTPMQuote `json:"tpm_quote,omitempty"`
 }
 
-// envelope is the self-describing {platform, evidence} wrapper.
-type envelope struct {
-	Platform string          `json:"platform"`
-	Evidence json.RawMessage `json:"evidence"`
-}
-
 // decoded holds the pieces pulled out of an az-snp envelope.
 type decoded struct {
 	hcl   *tpmcommon.HCLReport
@@ -69,80 +63,6 @@ func decode(ev azSnpEvidence) (*decoded, error) {
 	}
 	return d, nil
 }
-
-// --- Back-compat lightweight API (used by TEErminator's policy layer) ---
-
-// Result is the lightweight result of az-snp hardware verification: the launch
-// measurement, report_data, HCL var_data (vTPM AK material), and decoded vTPM
-// quote. Use VerifyVTPMFreshness to bind a nonce.
-type Result struct {
-	Measurement string
-	ReportData  []byte
-	VarData     []byte
-	TPMQuote    *tpmcommon.TPMQuote
-}
-
-// Verify verifies the SNP hardware report inside an az-snp envelope (signature +
-// VCEK chain + policy via the snp package) and returns the launch measurement,
-// report_data, var_data, and decoded vTPM quote. It does not enforce freshness;
-// use Result.VerifyVTPMFreshness.
-func Verify(raw []byte) (*Result, error) {
-	var env envelope
-	if err := json.Unmarshal(raw, &env); err != nil {
-		return nil, fmt.Errorf("parsing az-snp envelope: %w", err)
-	}
-	if env.Platform != string(teetypes.PlatformAzSNP) {
-		return nil, fmt.Errorf("unexpected platform %q, want %q", env.Platform, teetypes.PlatformAzSNP)
-	}
-	var ev azSnpEvidence
-	if err := json.Unmarshal(env.Evidence, &ev); err != nil {
-		return nil, fmt.Errorf("parsing az-snp evidence: %w", err)
-	}
-	d, err := decode(ev)
-	if err != nil {
-		return nil, err
-	}
-	hw, err := snp.VerifyReport(d.hcl.TEEReport, d.vcek, teetypes.VerifyParams{}, teetypes.PlatformAzSNP, snp.MinReportVersionAzure, snp.Options{})
-	if err != nil {
-		return nil, err
-	}
-	return &Result{
-		Measurement: hw.Claims.LaunchDigest,
-		ReportData:  hw.Claims.ReportData,
-		VarData:     d.hcl.VarData,
-		TPMQuote:    d.quote,
-	}, nil
-}
-
-// VerifyAttestation reports only whether the az-snp hardware report is valid.
-func VerifyAttestation(raw []byte) error {
-	_, err := Verify(raw)
-	return err
-}
-
-// VerifyVTPMFreshness verifies the az-snp vTPM trust chain binds nonce:
-// report_data == SHA-256(var_data) → AK pub → AK-signed quote → quote extraData
-// == nonce. PCR digest integrity is checked too.
-func (r *Result) VerifyVTPMFreshness(nonce []byte) error {
-	if r.TPMQuote == nil {
-		return fmt.Errorf("evidence carries no vTPM quote")
-	}
-	if len(r.VarData) == 0 {
-		return fmt.Errorf("HCL report carries no var_data to bind the vTPM AK")
-	}
-	if err := tpmcommon.VerifyHCLVarDataBinding(r.ReportData, r.VarData); err != nil {
-		return err
-	}
-	if err := tpmcommon.VerifyTPMSignature(r.TPMQuote.Signature, r.TPMQuote.Message, r.VarData); err != nil {
-		return err
-	}
-	if err := tpmcommon.VerifyTPMPCRs(r.TPMQuote.Message, r.TPMQuote.PCRs); err != nil {
-		return err
-	}
-	return tpmcommon.VerifyTPMNonce(r.TPMQuote.Message, nonce)
-}
-
-// --- Unified API (used by the dispatcher) ---
 
 // VerifyEvidence verifies the inner az-snp evidence payload end to end against
 // params: the vTPM trust chain, the SNP hardware report, the var_data binding,

--- a/attestation/azsnp/azsnp_test.go
+++ b/attestation/azsnp/azsnp_test.go
@@ -14,35 +14,29 @@ import (
 //go:embed testdata/attestation.json
 var attestationFixture []byte
 
-// TestVerify_Fixture verifies a real recorded az-snp envelope through the
-// back-compat API (hardware verify) and the vTPM components.
-func TestVerify_Fixture(t *testing.T) {
-	res, err := Verify(attestationFixture)
+// TestDecode_AKPub decodes the real recorded az-snp fixture and checks the HCL
+// var_data carries a well-formed RSA-2048 vTPM AK.
+func TestDecode_AKPub(t *testing.T) {
+	var env struct {
+		Evidence json.RawMessage `json:"evidence"`
+	}
+	if err := json.Unmarshal(attestationFixture, &env); err != nil {
+		t.Fatal(err)
+	}
+	var ev azSnpEvidence
+	if err := json.Unmarshal(env.Evidence, &ev); err != nil {
+		t.Fatal(err)
+	}
+	d, err := decode(ev)
 	if err != nil {
-		t.Fatalf("Verify: %v", err)
+		t.Fatalf("decode: %v", err)
 	}
-	if res.Measurement == "" || len(res.ReportData) != 64 {
-		t.Fatalf("unexpected result: measurement=%q reportData=%d", res.Measurement, len(res.ReportData))
-	}
-	if len(res.VarData) == 0 || res.TPMQuote == nil {
+	if len(d.hcl.VarData) == 0 || d.quote == nil {
 		t.Fatal("expected var_data + tpm_quote to be surfaced")
 	}
-
-	// vTPM components verify against real evidence.
-	if err := tpmcommon.VerifyHCLVarDataBinding(res.ReportData, res.VarData); err != nil {
-		t.Fatalf("var_data binding: %v", err)
-	}
-	if err := tpmcommon.VerifyTPMSignature(res.TPMQuote.Signature, res.TPMQuote.Message, res.VarData); err != nil {
-		t.Fatalf("AK signature: %v", err)
-	}
-	pub, err := tpmcommon.ExtractAKPub(res.VarData)
+	pub, err := tpmcommon.ExtractAKPub(d.hcl.VarData)
 	if err != nil || len(pub.N.Bytes()) != 256 || pub.E != 65537 {
 		t.Fatalf("AK pub: %v (N=%d E=%d)", err, len(pub.N.Bytes()), pub.E)
-	}
-
-	// Recorded evidence has empty qualifyingData → a fresh nonce fails closed.
-	if err := res.VerifyVTPMFreshness(make([]byte, 32)); err == nil {
-		t.Fatal("recorded evidence must fail freshness against a fresh nonce")
 	}
 }
 
@@ -111,11 +105,11 @@ func TestVerifyEvidence_LaunchDigestForwarded(t *testing.T) {
 	}
 }
 
-func TestVerify_Errors(t *testing.T) {
-	if err := VerifyAttestation([]byte("not json")); err == nil {
+func TestVerifyEvidence_Errors(t *testing.T) {
+	if _, err := VerifyEvidence([]byte("not json"), teetypes.VerifyParams{}, snp.Options{}); err == nil {
 		t.Fatal("garbage should fail")
 	}
-	if err := VerifyAttestation([]byte(`{"platform":"snp","evidence":{}}`)); err == nil {
-		t.Fatal("wrong platform should fail")
+	if _, err := VerifyEvidence([]byte(`{"version":99}`), teetypes.VerifyParams{}, snp.Options{}); err == nil {
+		t.Fatal("unsupported evidence version should fail")
 	}
 }

--- a/attestation/aztdx/aztdx.go
+++ b/attestation/aztdx/aztdx.go
@@ -27,91 +27,9 @@ type azTdxEvidence struct {
 	TPMQuote  *tpmcommon.RawTPMQuote `json:"tpm_quote"`
 }
 
-// envelope is the self-describing {platform, evidence} wrapper.
-type envelope struct {
-	Platform string          `json:"platform"`
-	Evidence json.RawMessage `json:"evidence"`
-}
-
-// --- Back-compat lightweight API (mirrors azsnp; used by TEErminator's Flow A
-// policy layer so one tls-header remote can be backed by SNP or TDX) ---
-
-// Result is the lightweight result of az-tdx hardware verification: the launch
-// measurement (MRTD), the TD report's report_data, the HCL var_data (vTPM AK
-// material), and the decoded vTPM quote. Use VerifyVTPMFreshness to bind a
-// nonce. Mirrors azsnp.Result so callers can treat both Azure vTPM platforms
-// uniformly.
-type Result struct {
-	Measurement string
-	ReportData  []byte
-	VarData     []byte
-	TPMQuote    *tpmcommon.TPMQuote
-}
-
-// Verify verifies the TD quote inside an az-tdx envelope (Intel DCAP signature +
-// chain via the tdx package) and returns the MRTD launch measurement, the TD
-// report_data, the HCL var_data, and the decoded vTPM quote. It does not enforce
-// freshness; use Result.VerifyVTPMFreshness. Mirrors azsnp.Verify.
-func Verify(raw []byte) (*Result, error) {
-	var env envelope
-	if err := json.Unmarshal(raw, &env); err != nil {
-		return nil, fmt.Errorf("parsing az-tdx envelope: %w", err)
-	}
-	if env.Platform != string(teetypes.PlatformAzTDX) {
-		return nil, fmt.Errorf("unexpected platform %q, want %q", env.Platform, teetypes.PlatformAzTDX)
-	}
-	var ev azTdxEvidence
-	if err := json.Unmarshal(env.Evidence, &ev); err != nil {
-		return nil, fmt.Errorf("parsing az-tdx evidence: %w", err)
-	}
-	hcl, tdQuoteBytes, quote, err := decode(ev)
-	if err != nil {
-		return nil, err
-	}
-	hw, err := tdx.VerifyQuoteBytes(tdQuoteBytes, teetypes.VerifyParams{}, teetypes.PlatformAzTDX, tdx.Options{})
-	if err != nil {
-		return nil, err
-	}
-	return &Result{
-		Measurement: hw.Claims.LaunchDigest,
-		ReportData:  hw.Claims.ReportData,
-		VarData:     hcl.VarData,
-		TPMQuote:    quote,
-	}, nil
-}
-
-// VerifyAttestation reports only whether the az-tdx TD quote is valid.
-func VerifyAttestation(raw []byte) error {
-	_, err := Verify(raw)
-	return err
-}
-
-// VerifyVTPMFreshness verifies the az-tdx vTPM trust chain binds nonce:
-// TD report_data == SHA-256(var_data) → AK pub → AK-signed quote → quote
-// extraData == nonce. PCR digest integrity is checked too. Mirrors
-// azsnp.Result.VerifyVTPMFreshness — the tpmcommon chain is platform-agnostic.
-func (r *Result) VerifyVTPMFreshness(nonce []byte) error {
-	if r.TPMQuote == nil {
-		return fmt.Errorf("evidence carries no vTPM quote")
-	}
-	if len(r.VarData) == 0 {
-		return fmt.Errorf("HCL report carries no var_data to bind the vTPM AK")
-	}
-	if err := tpmcommon.VerifyHCLVarDataBinding(r.ReportData, r.VarData); err != nil {
-		return err
-	}
-	if err := tpmcommon.VerifyTPMSignature(r.TPMQuote.Signature, r.TPMQuote.Message, r.VarData); err != nil {
-		return err
-	}
-	if err := tpmcommon.VerifyTPMPCRs(r.TPMQuote.Message, r.TPMQuote.PCRs); err != nil {
-		return err
-	}
-	return tpmcommon.VerifyTPMNonce(r.TPMQuote.Message, nonce)
-}
-
 // decode pulls the HCL report, raw TD quote bytes, and decoded vTPM quote out of
 // an az-tdx evidence payload, enforcing the required tpm_quote and TDX report
-// type. Shared by Verify and VerifyEvidence.
+// type.
 func decode(ev azTdxEvidence) (*tpmcommon.HCLReport, []byte, *tpmcommon.TPMQuote, error) {
 	if ev.TPMQuote == nil {
 		return nil, nil, nil, fmt.Errorf("az-tdx evidence is missing the required tpm_quote")
@@ -137,8 +55,6 @@ func decode(ev azTdxEvidence) (*tpmcommon.HCLReport, []byte, *tpmcommon.TPMQuote
 	}
 	return hcl, tdQuoteBytes, quote, nil
 }
-
-// --- Unified API (used by the dispatcher) ---
 
 // VerifyEvidence verifies the inner az-tdx evidence payload end to end against
 // params: the vTPM trust chain, the Intel TDX DCAP quote, the var_data binding,

--- a/attestation/aztdx/aztdx_test.go
+++ b/attestation/aztdx/aztdx_test.go
@@ -48,30 +48,3 @@ func TestVerifyEvidence_Errors(t *testing.T) {
 		t.Fatal("bad version should fail")
 	}
 }
-
-// TestVerify_LightweightAPI exercises the back-compat Verify/Result surface that
-// TEErminator's Flow A consumes: it takes the full {platform, evidence} envelope,
-// verifies the TD quote, and exposes the MRTD + a nonce-binding freshness check.
-func TestVerify_LightweightAPI(t *testing.T) {
-	res, err := Verify(azTdxFixture)
-	if err != nil {
-		t.Fatalf("Verify: %v", err)
-	}
-	if res.Measurement == "" {
-		t.Fatal("expected an MRTD launch measurement")
-	}
-	if len(res.ReportData) == 0 || len(res.VarData) == 0 || res.TPMQuote == nil {
-		t.Fatalf("incomplete result: %+v", res)
-	}
-
-	// A fresh (unbound) nonce must fail closed: the recorded quote's extraData
-	// binds a different value.
-	if err := res.VerifyVTPMFreshness(make([]byte, 32)); err == nil {
-		t.Fatal("fresh nonce must be rejected on recorded evidence")
-	}
-
-	// A platform-tagged non-TDX envelope is rejected by the envelope guard.
-	if _, err := Verify([]byte(`{"platform":"az-snp","evidence":{}}`)); err == nil {
-		t.Fatal("az-snp envelope must be rejected by aztdx.Verify")
-	}
-}


### PR DESCRIPTION
## Summary

Stacked on `feat/aztdx-verify-parity`.

The lightweight back-compat surface — `Verify`, `VerifyAttestation`, `Result`, `Result.VerifyVTPMFreshness`, and the `{platform, evidence}` envelope parsing they needed — existed for the header-based attestation flow of downstream proxies, which has now been removed everywhere (the header flow no longer exists in c8s, and the proxy consumes only `teeverify`). This removes that surface from both `azsnp` and `aztdx`, including the aztdx parity API introduced on the base branch.

All verification goes through the unified `teeverify` dispatcher and the per-platform `VerifyEvidence` entry points, which cover the same chain (hardware report, var_data binding, AK-signed vTPM quote, nonce and init-data freshness) with params-driven policy, and are what attestation-rs mirrors.

- No consumers break: the sibling proxy uses `teeverify`/`teetypes` only, and c8s does not import these symbols.
- Test coverage is preserved via the `VerifyEvidence` fixture tests; the AK-pub extraction check moves to a decode-level test and the error-path tests target `VerifyEvidence` directly.

## Test plan

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass.
- Repo-wide grep confirms no remaining references to the removed flow or API.