### PR TITLE
feat(tdx): replay the CCEL against the quote's RTMRs, plus parity hardening

### DIFF
--- a/attestation/PARITY.md
+++ b/attestation/PARITY.md
@@ -1,8 +1,8 @@
 # Go ↔ Rust verifier parity
 
 This tracks how the Go evidence-envelope verifiers (`snp`, `tdx`, `az-snp`,
-`az-tdx`, `gcp-*`) compare to the reference implementation in `attestation-rs`,
-following a check-by-check audit of both codebases.
+`az-tdx`, `gcp-*`) compare to `attestation-rs`, following check-by-check audits
+of both codebases (most recently 2026-07-20, against attestation-rs `e967531`).
 
 ## Summary
 
@@ -11,51 +11,129 @@ roots, report/quote signatures, the QE report binding, the vTPM AK-to-hardware
 binding, PCR recomputation, report_data/nonce freshness, VMPL=0, and debug-policy
 gating all match. The shared vTPM layer (`tpmcommon`) and the dispatcher
 (`teeverify`) are faithful ports, and the untrusted `platform` envelope tag
-cannot select a weaker verification path.
+cannot select a weaker verification path on either side.
 
-The divergences are concentrated in **collateral / revocation / TCB policy** —
-the checks that depend on live Intel/AMD collateral rather than static crypto —
-and several are bounded by what `go-sev-guest` / `go-tdx-guest` expose.
+Two things are worth stating plainly, because earlier revisions of this document
+got them backwards:
 
-## Fixed in this branch
+1. **attestation-rs is not uniformly the stronger implementation.** On several
+   verification-policy questions Go is now strictly stricter, and at least one
+   Go security fix has no Rust counterpart (see "Where Go is ahead").
+2. Divergences that *look* like Go deficiencies are often Rust fail-opens. The
+   "Go is bounded by go-sev-guest / go-tdx-guest" framing is accurate for
+   collateral plumbing, but not for policy enforcement.
+
+## Where Go is ahead of attestation-rs
+
+These are **not** Go gaps. They are listed so nobody "fixes" Go by relaxing it
+toward the reference.
+
+| Item | Platform | Status |
+|------|----------|--------|
+| **PCR[8] init-data spoof.** `CheckInitData` requires index 8 to be inside the quote's signed `pcrSelect` before trusting `pcrs[8]`. attestation-rs's `check_init_data` (`tpm_common.rs:650`) takes no quote message and indexes `tpm_pcrs[8]` unconditionally; since `verify_tpm_pcrs` only hashes *selected* PCRs, an unselected `pcrs[8]` is uncovered by the AK signature. Reachable in Rust natively **and** via the WASM entrypoints. | az-snp, az-tdx | Fixed in Go (#16). **Open in attestation-rs — reported upstream.** |
+| **Expected-measurement mismatch is fatal.** Go pushes `ExpectedLaunchDigest` / `ExpectedRTMRs` into the upstream validator, so a mismatch is an error. Rust `main` records `Some(false)` and still returns `Ok` with `signature_valid: true` — a launch-measurement pin is advisory unless the caller inspects a nullable bool. | all | Go fail-closed. Rust's unmerged `fix/expected-refs-hard-fail` adopts Go's semantics. |
+| **TDX TCB status.** go-tdx-guest hard-requires `UpToDate`. Rust accepts any non-`Revoked` status (`tdx/verify.rs:400`) and defers to the caller — and no in-tree Rust caller checks it. | tdx, az-tdx | Go fail-closed, Rust fail-open. Only bites when collateral is fetched. |
+| **SNP TCB relationships.** Even with `PermitProvisionalFirmware: true`, go-sev-guest still enforces `committed ≤ current`, committed build/API ≤ current, cert TCB == reported TCB, and the launch-TCB floor. Rust has no committed/current/launch TCB checks at all — only a `reported_tcb` floor. | snp, az-snp | Go stronger. Note #14 relaxed Go *toward* Rust here; do not relax further. |
+| **XFAM / TD_ATTRIBUTES reserved bits.** go-tdx-guest enforces the fixed-0/fixed-1 masks on every quote. Rust only surfaces these fields in claims. | tdx, az-tdx | Go stronger (defence in depth; the TDX module also enforces them). |
+
+## Fixed in Go
 
 | Item | Platform | What changed |
 |------|----------|--------------|
-| VLEK-signed reports were unverifiable (only `VcekCert` was ever populated → `ErrMissingVlek`) | snp, az-snp | `VerifyReport` now parses `SIGNER_INFO` and routes the endorsement cert to `VcekCert` or `VlekCert` (ARK→ASVK→VLEK). |
-| az-snp could never reach CRL revocation (dispatcher called `VerifyEvidence` with no options) | az-snp | `azsnp.VerifyEvidence` takes `snp.Options`; the dispatcher threads `opts.SNP` through, so a `Getter`+`CheckRevocations` now enables VCEK revocation on the Azure path. |
-| No way to pin the launch measurement / RTMRs | snp, tdx, az-snp, az-tdx | `VerifyParams` gains `ExpectedLaunchDigest` (→ SNP `MEASUREMENT` / TDX `MR_TD`) and `ExpectedRTMRs` (→ TDX `RTMRs`); result gains `LaunchDigestMatch`. Forwarded to the HW layer on the Azure paths too. |
+| VLEK-signed reports were unverifiable (only `VcekCert` was ever populated → `ErrMissingVlek`) | snp, az-snp | `VerifyReport` parses `SIGNER_INFO` and routes the endorsement cert to `VcekCert` or `VlekCert` (ARK→ASVK→VLEK). |
+| az-snp could never reach CRL revocation (dispatcher called `VerifyEvidence` with no options) | az-snp | `azsnp.VerifyEvidence` takes `snp.Options`; the dispatcher threads `opts.SNP` through. |
+| No way to pin the launch measurement / RTMRs | snp, tdx, az-snp, az-tdx | `VerifyParams` gains `ExpectedLaunchDigest` (→ SNP `MEASUREMENT` / TDX `MR_TD`) and `ExpectedRTMRs`; mismatches are errors. |
+| Init-data could be spoofed via an unselected PCR[8] | az-snp, az-tdx | `CheckInitData` re-derives the signed selection from the quote message and requires PCR 8 to be present. |
+| **CCEL eventlog → RTMR replay** (was "not yet ported") | tdx | `tdx/ccel.go` parses the TCG2 event log and replays it into RTMR[0-3]. `VerifyEvidence` enforces RTMR[0-2] and reports RTMR[3]. |
+| **`MinTCB.FMC` was silently dropped** | snp, az-snp | A caller-supplied FMC floor is now an explicit error instead of being ignored, so nobody believes they pinned a floor they did not get. |
+| **No per-field size caps on direct calls** | tdx, az-snp, az-tdx | `teetypes.CheckFieldSize` (1 MiB, mirroring Rust's `MAX_EVIDENCE_FIELD_SIZE`) bounds `hcl_report`, `vcek`/`td_quote`/`quote`, `cc_eventlog`, and the vTPM quote fields. |
+
+### CCEL replay semantics
+
+The Go port follows attestation-rs `ff879e5`: **RTMR[0-2] are enforced, RTMR[3]
+is reported only.** RTMR[3] is the runtime-extendable register and the guest
+kernel's `tdx_guest` sysfs extend appends no CCEL entry, so a replay divergence
+there is expected on any guest that runtime-extends — enforcing all four
+registers would reject legitimate evidence.
+
+Because this package is a pure library with no logger, the RTMR[3] outcome is
+surfaced programmatically rather than via Rust's `log::warn!`:
+
+- `VerificationResult.EventlogVerified` — nil when no event log was supplied;
+  true when the replay reproduced RTMR[0-2]. A mismatch is an error.
+- `VerificationResult.RTMR3ReplayMatch` — nil when no event log was supplied,
+  else whether RTMR[3] replayed. **False is normal, not a failure.**
+
+Pin RTMR[3] with `VerifyParams.ExpectedRTMRs`, which is checked against the
+signed quote rather than the event log.
+
+Scope note: only bare-metal `tdx` evidence carries `cc_eventlog`. The az-tdx
+envelope has no event log in either implementation.
 
 ## Known gaps — bounded by the upstream libraries
 
 These require upstream support (or a hand-rolled reimplementation of DCAP/CRL
 logic) and were intentionally **not** faked:
 
-- **TDX TCB-status semantics & surfacing.** `go-tdx-guest`'s `TdxQuote` returns
-  only `error` and hard-requires `UpToDate`, so (a) it cannot return the TCB
-  status string (`DcapVerificationStatus`/`TCBStatus` stays unset), and (b) it
-  is *stricter* than Rust, which accepts any non-`Revoked` status and hands it
-  to the caller. Matching Rust would mean reimplementing collateral evaluation.
-- **TDX collateral is opt-in** (`GetCollateral=false` by default), matching
-  Rust's "no provider" default — but callers assuming parity must remember to
-  enable it to get TCB-status / QE-identity / CRL checks.
 - **SNP CRL checks the ASK serial, not the VCEK serial.** `go-sev-guest`'s
-  `verifyCRL` explicitly declines to check VCEK serials; Rust checks the VCEK
-  serial against the CRL.
-- **FMC (Turin) min-TCB floor is not enforced.** `kds.TCBParts` has no FMC
-  field, so a caller-supplied `MinTCB.FMC` cannot be mapped onto
-  `validate.MinimumTCB`. Rust enforces it.
+  `verifyCRL` explicitly declines to check VCEK serials (`VcekNotRevokedContext`
+  discards its certificate argument); Rust checks the VCEK serial against the
+  CRL. A revoked VCEK is accepted by Go even with `CheckRevocations: true`.
+- **Turin is not verifiable in Go at all.** `go-sev-guest`'s OID table has no
+  entry for the FMC extension `1.3.6.1.4.1.3704.1.3.9`, so a Turin VCEK fails
+  certificate parsing before any crypto runs; it also requires a 64-byte HWID,
+  while Turin uses a short (8-byte) CHIP_ID. Rust supports Turin fully
+  (bundled Turin ARK/ASK/ASVK, FMC parsing, short HW_ID). This subsumes the
+  `MinTCB.FMC` gap — the floor is unenforceable *and* the platform is
+  unreachable.
+- **TDX TCB status is not surfaced.** `go-tdx-guest`'s `TdxQuote` returns only
+  `error`, so `TCBStatus` / `DcapVerificationStatus` stays unset even though the
+  underlying check is stricter than Rust's (see "Where Go is ahead").
+- **Go is TDX-v4 only.** Rust parses v4 and v5 (TDX 1.5, `tee_tcb_svn2`,
+  `mr_servicetd`). Fails closed; an availability gap, not a security one.
 
-## Not yet ported
+## Remaining differences worth knowing
 
-- **CCEL eventlog → RTMR replay** (TDX). Rust replays the CCEL to confirm it
-  reproduces RTMR0-3; Go carries `cc_eventlog` but does not verify it. The RTMRs
-  themselves are still signed in the quote, so this is bounded, but there is no
-  cryptographic eventlog↔RTMR link. A focused follow-up.
+- **Collateral default.** Rust's `Verifier::new()` installs live cert and TDX
+  collateral providers, so the convenience `attestation::verify()` does CRL /
+  TCB-status / QE-identity checks by default. Go's `teeverify.Verify()` is
+  offline by default (`Options{}`) and documents this; use `VerifyWithOptions`
+  for collateral. Both are fail-open-by-default in the sense that a caller who
+  never asks for collateral never gets it, but the defaults differ — do not
+  assume parity here.
+- **`CollateralVerified` semantics.** Go sets it from the request flags; Rust
+  sets it from whether checks actually ran (`tcb_status.is_some()`).
+- **Result shape.** Rust surfaces `mrtd_match` and `rtmr0..3_match`; Go folds
+  MR_TD into `LaunchDigestMatch` and has no per-RTMR booleans. Since Go errors
+  on mismatch, a missing boolean cannot hide a failed check — but the serialized
+  shapes differ.
+- **Envelope size cap.** Go caps the envelope at 1 MiB, Rust at 10 MiB (with a
+  1 MiB per-field cap that Go now mirrors).
+- **`ExpectedRTMRs` ergonomics.** Go accepts a slice shorter than 4 and treats
+  the tail as unspecified, so passing 2 entries intending RTMR[2],RTMR[3]
+  silently pins RTMR[0],RTMR[1]. Rust's flattened per-RTMR fields avoid the
+  ambiguity.
+- **`dstack`** is declared in `teetypes` but has no dispatcher case (fails
+  closed); Rust verifies it via the TDX path.
+- **NVIDIA GPU attestation** exists only in Rust. A Go verifier handed a
+  GPU-bearing envelope ignores the GPU evidence rather than rejecting it —
+  harmless today (no Go caller expects GPU claims), but it would become
+  fail-open the moment one does.
 
 ## Separate concern — legacy GCE vTPM path
 
 `attestation/verify.go` + `verify_sev.go` / `verify_tdx.go` is a distinct
-`go-tpm-tools` proto-based verifier (not the evidence-envelope path). It is
-materially weaker than both `snp.go`/`tdx.go` and the Rust reference (zero-value
-options, no VMPL pin, no min-TCB, KDS fetch on) and should be reviewed
-separately if still reachable in production.
+`go-tpm-tools` proto-based verifier, not the evidence-envelope path. It is
+materially weaker than both `snp.go`/`tdx.go` and the Rust reference:
+
+- `verify_sev.go:24` sets **no VMPL pin**, so a report generated at VMPL 1-3 is
+  accepted (the envelope path pins VMPL 0). Rust hard-rejects `vmpl != 0` on
+  every path.
+- `verify_tdx.go:17` passes empty validation options — **no debug gating**.
+- Both run with zero-value verification options: KDS cert fetching on, no
+  revocation checks.
+
+**This path is reachable**: `attestation.VerifyAttestation` is exported and
+re-exported as a C FFI symbol in `cmd/ffi/main.go`. It should either be hardened
+(pin VMPL 0, gate debug, disable cert fetching) or removed if no consumer
+remains.

--- a/attestation/azsnp/azsnp.go
+++ b/attestation/azsnp/azsnp.go
@@ -30,6 +30,27 @@ type azSnpEvidence struct {
 	TPMQuote  *tpmcommon.RawTPMQuote `json:"tpm_quote,omitempty"`
 }
 
+// checkFieldSizes bounds each evidence field. The dispatcher already caps the
+// whole envelope, but VerifyEvidence is exported and may be called directly.
+// Mirrors attestation-rs's check_field_size calls in az_snp::verify.
+func checkFieldSizes(ev azSnpEvidence) error {
+	if err := teetypes.CheckFieldSize("hcl_report", len(ev.HCLReport)); err != nil {
+		return fmt.Errorf("az-snp: %w", err)
+	}
+	if err := teetypes.CheckFieldSize("vcek", len(ev.Vcek)); err != nil {
+		return fmt.Errorf("az-snp: %w", err)
+	}
+	if ev.TPMQuote != nil {
+		if err := teetypes.CheckFieldSize("tpm_quote.message", len(ev.TPMQuote.Message)); err != nil {
+			return fmt.Errorf("az-snp: %w", err)
+		}
+		if err := teetypes.CheckFieldSize("tpm_quote.signature", len(ev.TPMQuote.Signature)); err != nil {
+			return fmt.Errorf("az-snp: %w", err)
+		}
+	}
+	return nil
+}
+
 // decoded holds the pieces pulled out of an az-snp envelope.
 type decoded struct {
 	hcl   *tpmcommon.HCLReport
@@ -80,6 +101,9 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts snp.Options
 	}
 	if ev.Version != 1 {
 		return nil, fmt.Errorf("unsupported az-snp evidence version: %d", ev.Version)
+	}
+	if err := checkFieldSizes(ev); err != nil {
+		return nil, err
 	}
 	d, err := decode(ev)
 	if err != nil {

--- a/attestation/aztdx/aztdx.go
+++ b/attestation/aztdx/aztdx.go
@@ -27,6 +27,27 @@ type azTdxEvidence struct {
 	TPMQuote  *tpmcommon.RawTPMQuote `json:"tpm_quote"`
 }
 
+// checkFieldSizes bounds each evidence field. The dispatcher already caps the
+// whole envelope, but VerifyEvidence is exported and may be called directly.
+// Mirrors attestation-rs's check_field_size calls in az_tdx::verify.
+func checkFieldSizes(ev azTdxEvidence) error {
+	if err := teetypes.CheckFieldSize("hcl_report", len(ev.HCLReport)); err != nil {
+		return fmt.Errorf("az-tdx: %w", err)
+	}
+	if err := teetypes.CheckFieldSize("td_quote", len(ev.TDQuote)); err != nil {
+		return fmt.Errorf("az-tdx: %w", err)
+	}
+	if ev.TPMQuote != nil {
+		if err := teetypes.CheckFieldSize("tpm_quote.message", len(ev.TPMQuote.Message)); err != nil {
+			return fmt.Errorf("az-tdx: %w", err)
+		}
+		if err := teetypes.CheckFieldSize("tpm_quote.signature", len(ev.TPMQuote.Signature)); err != nil {
+			return fmt.Errorf("az-tdx: %w", err)
+		}
+	}
+	return nil
+}
+
 // decode pulls the HCL report, raw TD quote bytes, and decoded vTPM quote out of
 // an az-tdx evidence payload, enforcing the required tpm_quote and TDX report
 // type.
@@ -68,6 +89,9 @@ func VerifyEvidence(inner []byte, params teetypes.VerifyParams, opts tdx.Options
 	}
 	if ev.Version != 1 {
 		return nil, fmt.Errorf("unsupported az-tdx evidence version: %d", ev.Version)
+	}
+	if err := checkFieldSizes(ev); err != nil {
+		return nil, err
 	}
 
 	hcl, tdQuoteBytes, quote, err := decode(ev)

--- a/attestation/snp/snp.go
+++ b/attestation/snp/snp.go
@@ -239,11 +239,17 @@ func validateOptions(params teetypes.VerifyParams) (*validate.Options, error) {
 		opts.Measurement = d
 	}
 	if t := params.MinTCB; t != nil {
-		// NOTE: the FMC (Turin) TCB component is intentionally not enforced here:
-		// go-sev-guest v0.15.0's kds.TCBParts has no FMC field, so a caller-supplied
-		// MinTCB.FMC floor cannot be mapped onto validate.MinimumTCB. attestation-rs
-		// does enforce it; matching that requires upstream FMC support (or a manual
-		// reported-TCB comparison). Tracked as a known parity gap.
+		// The FMC (Turin) TCB component cannot be enforced: go-sev-guest v0.15.0's
+		// kds.TCBParts has no FMC field, so a caller-supplied MinTCB.FMC floor
+		// cannot be mapped onto validate.MinimumTCB. attestation-rs does enforce
+		// it. Reject rather than silently ignore — a caller that believes it set a
+		// floor and got none is the fail-open outcome. (Moot in practice today:
+		// go-sev-guest cannot parse a Turin VCEK's FMC extension, so Turin reports
+		// fail earlier in the chain regardless. See PARITY.md.)
+		if t.FMC != nil {
+			return nil, fmt.Errorf("snp: MinTCB.FMC is not enforceable with go-sev-guest v0.15.0 " +
+				"(no FMC field in kds.TCBParts); unset it or pin the TCB via the other components")
+		}
 		opts.MinimumTCB = kds.TCBParts{
 			BlSpl:    t.Bootloader,
 			TeeSpl:   t.Tee,

--- a/attestation/snp/snp_test.go
+++ b/attestation/snp/snp_test.go
@@ -336,6 +336,17 @@ func TestValidateOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("MinTCB.FMC rejected rather than silently dropped", func(t *testing.T) {
+		fmc := uint8(7)
+		_, err := validateOptions(teetypes.VerifyParams{
+			MinTCB: &teetypes.SnpTcb{Bootloader: 1, Tee: 2, Snp: 3, Microcode: 4, FMC: &fmc},
+		})
+		if err == nil {
+			t.Fatal("an FMC floor is not enforceable with go-sev-guest and must be rejected, " +
+				"otherwise the caller believes it pinned a floor it did not get")
+		}
+	})
+
 	t.Run("oversize inputs rejected", func(t *testing.T) {
 		if _, err := validateOptions(teetypes.VerifyParams{ExpectedReportData: make([]byte, 65)}); err == nil {
 			t.Error("report_data > 64 should error")

--- a/attestation/tdx/ccel.go
+++ b/attestation/tdx/ccel.go
@@ -1,0 +1,236 @@
+package tdx
+
+import (
+	"crypto/sha512"
+	"crypto/subtle"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+// CCEL (CC Event Log) parsing and RTMR replay verification. Port of
+// attestation-rs's tdx::ccel.
+//
+// The CCEL is a TCG2-format event log stored in the ACPI CCEL table at
+// /sys/firmware/acpi/tables/data/CCEL. Each event targets an MR index (1-4,
+// mapping to RTMR[0-3]) and carries a SHA-384 digest. Replaying the events from
+// a zero-initialized state must reproduce the RTMR values in the TDX quote,
+// which binds the (otherwise unauthenticated) event log to the signed quote.
+//
+// Only RTMR[0-2] (the boot-time registers) are enforced. RTMR[3] is the
+// runtime-extendable register: the guest kernel's tdx_guest sysfs extend
+// interface appends no CCEL entry (the log area is firmware-owned), so any
+// legitimate runtime extend makes RTMR[3] unreplayable by construction. A
+// RTMR[3] divergence is therefore reported, not treated as an error; relying
+// parties pin quote.rtmr_3 directly via VerifyParams.ExpectedRTMRs.
+
+// maxDigestAlgorithms caps the per-event digest count. The TCG spec allows ~3;
+// a larger value means we have run off the end of the events into the padding
+// of the (typically 64 KiB) ACPI table.
+const maxDigestAlgorithms = 16
+
+// TCG algorithm identifiers and their digest sizes.
+const (
+	algoSHA1   = 0x0004
+	algoSHA256 = 0x000B
+	algoSHA384 = 0x000C
+	algoSHA512 = 0x000D
+)
+
+// CCELEvent is a parsed CCEL event.
+type CCELEvent struct {
+	// MRIndex is the measurement register index: 1=RTMR[0] .. 4=RTMR[3].
+	MRIndex uint32
+	// EventType is the TCG2 event type (e.g. 0x80000001 =
+	// EV_EFI_VARIABLE_DRIVER_CONFIG).
+	EventType uint32
+	// SHA384Digest is the event's SHA-384 digest (48 bytes).
+	SHA384Digest []byte
+	// EventData is the raw event payload; its structure depends on EventType.
+	EventData []byte
+}
+
+// digestSize returns the digest length for a TCG algorithm id.
+func digestSize(algoID uint16) (int, bool) {
+	switch algoID {
+	case algoSHA384:
+		return 48, true
+	case algoSHA512:
+		return 64, true
+	case algoSHA256:
+		return 32, true
+	case algoSHA1:
+		return 20, true
+	default:
+		return 0, false
+	}
+}
+
+// exceeds reports whether reading n bytes at off would run past the end of b.
+func exceeds(b []byte, off, n int) bool {
+	return off < 0 || n < 0 || off+n > len(b)
+}
+
+// ParseCCEL parses a CCEL binary blob into its events.
+//
+// The first record is a TCG Spec ID Event header (EV_NO_ACTION at PCR 0) and is
+// skipped; the remainder are TCG_PCR_EVENT2 structures. Parsing stops cleanly at
+// the first truncated or terminator record, since the ACPI table is zero-padded
+// well beyond the last real event.
+func ParseCCEL(data []byte) ([]CCELEvent, error) {
+	if len(data) < 32 {
+		return nil, fmt.Errorf("tdx: CCEL data too short: %d bytes", len(data))
+	}
+
+	// Spec ID Event: 32-byte TCG_PCR_EVENT header, then eventSize bytes of data.
+	eventSize := int(binary.LittleEndian.Uint32(data[28:32]))
+	if eventSize < 0 {
+		return nil, fmt.Errorf("tdx: CCEL Spec ID Event size overflow")
+	}
+	offset := 32 + eventSize
+	if offset < 32 || offset > len(data) {
+		return nil, fmt.Errorf("tdx: CCEL Spec ID Event size (%d) exceeds data (%d bytes)", eventSize, len(data))
+	}
+
+	var events []CCELEvent
+
+	for offset < len(data) {
+		if exceeds(data, offset, 8) {
+			break
+		}
+		mrIndex := binary.LittleEndian.Uint32(data[offset : offset+4])
+		eventType := binary.LittleEndian.Uint32(data[offset+4 : offset+8])
+
+		pos := offset + 8
+		if exceeds(data, pos, 4) {
+			break
+		}
+		digestCount := binary.LittleEndian.Uint32(data[pos : pos+4])
+		pos += 4
+
+		if digestCount > maxDigestAlgorithms {
+			// Ran into padding / uninitialized region of the CCEL table.
+			break
+		}
+
+		var sha384Digest []byte
+		truncated := false
+
+		for i := uint32(0); i < digestCount; i++ {
+			if exceeds(data, pos, 2) {
+				truncated = true
+				break
+			}
+			algoID := binary.LittleEndian.Uint16(data[pos : pos+2])
+			pos += 2
+
+			size, known := digestSize(algoID)
+			if !known {
+				return nil, fmt.Errorf("tdx: unsupported CCEL digest algorithm 0x%04X at offset %d", algoID, pos)
+			}
+			if exceeds(data, pos, size) {
+				truncated = true
+				break
+			}
+			if algoID == algoSHA384 {
+				sha384Digest = append([]byte(nil), data[pos:pos+size]...)
+			}
+			pos += size
+		}
+		if truncated {
+			break
+		}
+
+		if exceeds(data, pos, 4) {
+			break
+		}
+		eventDataSize := int(binary.LittleEndian.Uint32(data[pos : pos+4]))
+		pos += 4
+		if eventDataSize < 0 {
+			return nil, fmt.Errorf("tdx: CCEL event_data_size overflow")
+		}
+		eventEnd := pos + eventDataSize
+		if eventEnd < pos || eventEnd > len(data) {
+			break
+		}
+
+		// Terminator record: type=0, mr=0, size=0.
+		if eventType == 0 && mrIndex == 0 && eventDataSize == 0 {
+			break
+		}
+
+		if len(sha384Digest) != 0 {
+			events = append(events, CCELEvent{
+				MRIndex:      mrIndex,
+				EventType:    eventType,
+				SHA384Digest: sha384Digest,
+				EventData:    append([]byte(nil), data[pos:eventEnd]...),
+			})
+		}
+
+		offset = eventEnd
+	}
+
+	return events, nil
+}
+
+// ReplayRTMRs replays events to compute the four RTMR values.
+//
+// Each RTMR starts as 48 zero bytes and is extended per event:
+//
+//	RTMR_new = SHA384(RTMR_old || event_digest)
+//
+// The result is indexed [RTMR[0], RTMR[1], RTMR[2], RTMR[3]].
+func ReplayRTMRs(events []CCELEvent) [4][48]byte {
+	var rtmrs [4][48]byte
+
+	for _, ev := range events {
+		// MR index 1-4 maps to RTMR[0-3]; anything else is not an RTMR extend.
+		if ev.MRIndex < 1 || ev.MRIndex > 4 {
+			continue
+		}
+		idx := ev.MRIndex - 1
+
+		h := sha512.New384()
+		h.Write(rtmrs[idx][:])
+		h.Write(ev.SHA384Digest)
+		copy(rtmrs[idx][:], h.Sum(nil))
+	}
+
+	return rtmrs
+}
+
+// VerifyCCELAgainstRTMRs replays ccelData and checks it reproduces the RTMR
+// values from the TDX quote body.
+//
+// RTMR[0-2] are enforced: a mismatch is an error. RTMR[3] is only reported —
+// see the package notes above on runtime extends — so rtmr3Match is false for
+// any guest that extended RTMR[3] after boot, which is legitimate. Callers that
+// care about RTMR[3] pin it via VerifyParams.ExpectedRTMRs, which is checked
+// against the signed quote rather than the event log.
+//
+// Each rtmr argument must be 48 bytes.
+func VerifyCCELAgainstRTMRs(ccelData []byte, rtmr0, rtmr1, rtmr2, rtmr3 []byte) (rtmr3Match bool, err error) {
+	for i, r := range [][]byte{rtmr0, rtmr1, rtmr2, rtmr3} {
+		if len(r) != 48 {
+			return false, fmt.Errorf("tdx: RTMR[%d] is %d bytes (want 48)", i, len(r))
+		}
+	}
+
+	events, err := ParseCCEL(ccelData)
+	if err != nil {
+		return false, err
+	}
+	replayed := ReplayRTMRs(events)
+
+	for i, want := range [][]byte{rtmr0, rtmr1, rtmr2} {
+		if subtle.ConstantTimeCompare(replayed[i][:], want) != 1 {
+			return false, fmt.Errorf(
+				"tdx: CCEL eventlog integrity check failed: RTMR[%d] mismatch: replayed=%s, quote=%s",
+				i, hex.EncodeToString(replayed[i][:]), hex.EncodeToString(want),
+			)
+		}
+	}
+
+	return subtle.ConstantTimeCompare(replayed[3][:], rtmr3) == 1, nil
+}

--- a/attestation/tdx/ccel_test.go
+++ b/attestation/tdx/ccel_test.go
@@ -1,0 +1,310 @@
+package tdx
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+)
+
+// batchEvidence returns the {platform, evidence} entries of the live TDX
+// fixture, each of which carries a real CCEL event log.
+func batchEvidence(t *testing.T) []TdxEvidence {
+	t.Helper()
+	var batch []struct {
+		Platform string      `json:"platform"`
+		Evidence TdxEvidence `json:"evidence"`
+	}
+	if err := json.Unmarshal(tdxEvidenceBatch, &batch); err != nil {
+		t.Fatalf("parsing batch fixture: %v", err)
+	}
+	out := make([]TdxEvidence, 0, len(batch))
+	for _, e := range batch {
+		out = append(out, e.Evidence)
+	}
+	if len(out) == 0 {
+		t.Fatal("batch fixture is empty")
+	}
+	return out
+}
+
+// quoteRTMRsOf verifies the evidence and returns the quote's four RTMRs.
+func quoteRTMRsOf(t *testing.T, ev TdxEvidence) [4][]byte {
+	t.Helper()
+	quoteBytes, err := base64.StdEncoding.DecodeString(ev.Quote)
+	if err != nil {
+		t.Fatalf("decoding quote: %v", err)
+	}
+	rtmrs, err := quoteRTMRs(quoteBytes)
+	if err != nil {
+		t.Fatalf("extracting RTMRs: %v", err)
+	}
+	return rtmrs
+}
+
+// TestParseCCEL_LiveFixture checks the parser against real CCEL blobs: every
+// event must carry a 48-byte SHA-384 digest and target a valid MR index.
+func TestParseCCEL_LiveFixture(t *testing.T) {
+	for i, ev := range batchEvidence(t) {
+		t.Run(fmt.Sprintf("entry-%d", i), func(t *testing.T) {
+			ccel, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+			if err != nil {
+				t.Fatalf("decoding cc_eventlog: %v", err)
+			}
+			events, err := ParseCCEL(ccel)
+			if err != nil {
+				t.Fatalf("ParseCCEL: %v", err)
+			}
+			if len(events) == 0 {
+				t.Fatal("expected a non-empty event log")
+			}
+			for j, e := range events {
+				if len(e.SHA384Digest) != 48 {
+					t.Errorf("event %d: digest is %d bytes, want 48", j, len(e.SHA384Digest))
+				}
+				if e.MRIndex < 1 || e.MRIndex > 4 {
+					t.Errorf("event %d: MR index %d out of range 1..4", j, e.MRIndex)
+				}
+			}
+		})
+	}
+}
+
+// TestVerifyCCELAgainstRTMRs_LiveFixture is the core correctness check: the
+// replayed boot-time registers must reproduce the values signed in the quote.
+func TestVerifyCCELAgainstRTMRs_LiveFixture(t *testing.T) {
+	for i, ev := range batchEvidence(t) {
+		t.Run(fmt.Sprintf("entry-%d", i), func(t *testing.T) {
+			ccel, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+			if err != nil {
+				t.Fatalf("decoding cc_eventlog: %v", err)
+			}
+			r := quoteRTMRsOf(t, ev)
+
+			rtmr3Match, err := VerifyCCELAgainstRTMRs(ccel, r[0], r[1], r[2], r[3])
+			if err != nil {
+				t.Fatalf("live CCEL must replay to the quote's RTMR[0-2]: %v", err)
+			}
+			t.Logf("rtmr3 replay match: %v", rtmr3Match)
+
+			// The replay must be non-trivial: a zeroed RTMR[0] would pass if the
+			// parser silently produced no events.
+			events, err := ParseCCEL(ccel)
+			if err != nil {
+				t.Fatalf("ParseCCEL: %v", err)
+			}
+			replayed := ReplayRTMRs(events)
+			var zero [48]byte
+			if replayed[0] == zero {
+				t.Fatal("replayed RTMR[0] is all zeroes — the event log was not actually replayed")
+			}
+		})
+	}
+}
+
+// TestVerifyCCELAgainstRTMRs_TamperedBootRTMR ensures a boot-time register
+// mismatch is a hard failure.
+func TestVerifyCCELAgainstRTMRs_TamperedBootRTMR(t *testing.T) {
+	ev := batchEvidence(t)[0]
+	ccel, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+	if err != nil {
+		t.Fatalf("decoding cc_eventlog: %v", err)
+	}
+	r := quoteRTMRsOf(t, ev)
+
+	for i := 0; i < 3; i++ {
+		t.Run(fmt.Sprintf("rtmr-%d", i), func(t *testing.T) {
+			bad := [4][]byte{
+				append([]byte(nil), r[0]...),
+				append([]byte(nil), r[1]...),
+				append([]byte(nil), r[2]...),
+				append([]byte(nil), r[3]...),
+			}
+			bad[i][0] ^= 0xFF
+			if _, err := VerifyCCELAgainstRTMRs(ccel, bad[0], bad[1], bad[2], bad[3]); err == nil {
+				t.Fatalf("tampered RTMR[%d] must fail verification", i)
+			}
+		})
+	}
+}
+
+// TestVerifyCCELAgainstRTMRs_RuntimeExtendedRTMR3 pins the ff879e5 semantics: a
+// guest-side runtime extend changes RTMR[3] without a CCEL entry, so the replay
+// diverges but verification must still succeed — reported, not enforced.
+func TestVerifyCCELAgainstRTMRs_RuntimeExtendedRTMR3(t *testing.T) {
+	ev := batchEvidence(t)[0]
+	ccel, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+	if err != nil {
+		t.Fatalf("decoding cc_eventlog: %v", err)
+	}
+	r := quoteRTMRsOf(t, ev)
+
+	// Simulate a runtime extend: RTMR[3] = SHA384(RTMR[3] || digest).
+	h := sha512.New384()
+	h.Write(r[3])
+	h.Write(make([]byte, 48))
+	extended := h.Sum(nil)
+
+	rtmr3Match, err := VerifyCCELAgainstRTMRs(ccel, r[0], r[1], r[2], extended)
+	if err != nil {
+		t.Fatalf("runtime-extended RTMR[3] must not fail eventlog verification: %v", err)
+	}
+	if rtmr3Match {
+		t.Fatal("rtmr3Match should be false after a runtime extend")
+	}
+}
+
+// TestVerifyCCELAgainstRTMRs_TamperedEventlog flips a byte inside an event
+// digest; the replay must then diverge from the signed RTMRs.
+func TestVerifyCCELAgainstRTMRs_TamperedEventlog(t *testing.T) {
+	ev := batchEvidence(t)[0]
+	ccel, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+	if err != nil {
+		t.Fatalf("decoding cc_eventlog: %v", err)
+	}
+	r := quoteRTMRsOf(t, ev)
+
+	// Sanity: untampered log verifies.
+	if _, err := VerifyCCELAgainstRTMRs(ccel, r[0], r[1], r[2], r[3]); err != nil {
+		t.Fatalf("baseline CCEL should verify: %v", err)
+	}
+
+	// The first event's SHA-384 digest lives just past the Spec ID Event header
+	// and the event2 header; flipping any byte of the log body must break the
+	// replay. Locate it via the parser rather than hardcoding an offset.
+	events, err := ParseCCEL(ccel)
+	if err != nil {
+		t.Fatalf("ParseCCEL: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("no events to tamper with")
+	}
+	needle := events[0].SHA384Digest
+	idx := indexOf(ccel, needle)
+	if idx < 0 {
+		t.Fatal("could not locate the first event digest in the raw log")
+	}
+	tampered := append([]byte(nil), ccel...)
+	tampered[idx] ^= 0x01
+
+	if _, err := VerifyCCELAgainstRTMRs(tampered, r[0], r[1], r[2], r[3]); err == nil {
+		t.Fatal("a tampered event digest must break the RTMR replay")
+	}
+}
+
+// TestVerifyCCELAgainstRTMRs_Malformed covers the defensive parser paths.
+func TestVerifyCCELAgainstRTMRs_Malformed(t *testing.T) {
+	r := [4][]byte{make([]byte, 48), make([]byte, 48), make([]byte, 48), make([]byte, 48)}
+
+	t.Run("too-short", func(t *testing.T) {
+		if _, err := VerifyCCELAgainstRTMRs([]byte{1, 2, 3}, r[0], r[1], r[2], r[3]); err == nil {
+			t.Fatal("a truncated CCEL must be rejected")
+		}
+	})
+
+	t.Run("spec-id-size-overruns", func(t *testing.T) {
+		blob := make([]byte, 64)
+		// Spec ID Event size far beyond the buffer.
+		blob[28], blob[29], blob[30], blob[31] = 0xFF, 0xFF, 0x00, 0x00
+		if _, err := VerifyCCELAgainstRTMRs(blob, r[0], r[1], r[2], r[3]); err == nil {
+			t.Fatal("an out-of-range Spec ID Event size must be rejected")
+		}
+	})
+
+	t.Run("all-zero-padding-replays-empty", func(t *testing.T) {
+		// A well-formed header followed by zero padding yields no events, so the
+		// replay stays all-zero and must not match real RTMRs.
+		blob := make([]byte, 4096)
+		events, err := ParseCCEL(blob)
+		if err != nil {
+			t.Fatalf("ParseCCEL on zero padding: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("expected no events from zero padding, got %d", len(events))
+		}
+	})
+
+	t.Run("wrong-rtmr-length", func(t *testing.T) {
+		short := make([]byte, 32)
+		if _, err := VerifyCCELAgainstRTMRs(make([]byte, 64), short, r[1], r[2], r[3]); err == nil {
+			t.Fatal("a non-48-byte RTMR must be rejected")
+		}
+	})
+}
+
+// TestVerifyEvidence_EventlogWired proves the replay is reached from the
+// evidence entry point and reflected in the result.
+func TestVerifyEvidence_EventlogWired(t *testing.T) {
+	ev := batchEvidence(t)[0]
+
+	res, err := VerifyEvidence(ev, teetypes.VerifyParams{}, Options{})
+	if err != nil {
+		t.Fatalf("VerifyEvidence: %v", err)
+	}
+	if res.EventlogVerified == nil || !*res.EventlogVerified {
+		t.Fatal("EventlogVerified should be true when a CCEL is present and replays")
+	}
+	if res.RTMR3ReplayMatch == nil {
+		t.Fatal("RTMR3ReplayMatch should be reported when a CCEL is present")
+	}
+
+	// Evidence without an event log leaves both fields unset.
+	noLog := TdxEvidence{Quote: ev.Quote}
+	res, err = VerifyEvidence(noLog, teetypes.VerifyParams{}, Options{})
+	if err != nil {
+		t.Fatalf("VerifyEvidence without eventlog: %v", err)
+	}
+	if res.EventlogVerified != nil || res.RTMR3ReplayMatch != nil {
+		t.Fatal("eventlog fields must be nil when no CCEL is supplied")
+	}
+
+	// A corrupted event log must fail the whole verification, not be ignored.
+	corrupt := ev
+	raw, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+	if err != nil {
+		t.Fatalf("decoding cc_eventlog: %v", err)
+	}
+	events, err := ParseCCEL(raw)
+	if err != nil || len(events) == 0 {
+		t.Fatalf("ParseCCEL: %v", err)
+	}
+	idx := indexOf(raw, events[0].SHA384Digest)
+	if idx < 0 {
+		t.Fatal("could not locate the first event digest")
+	}
+	tampered := append([]byte(nil), raw...)
+	tampered[idx] ^= 0x01
+	corrupt.CCEventlog = base64.StdEncoding.EncodeToString(tampered)
+
+	if _, err := VerifyEvidence(corrupt, teetypes.VerifyParams{}, Options{}); err == nil {
+		t.Fatal("a tampered event log must fail VerifyEvidence")
+	}
+
+	// Non-base64 event log is a decode error, not a silent skip.
+	bad := ev
+	bad.CCEventlog = "!!!not-base64!!!"
+	if _, err := VerifyEvidence(bad, teetypes.VerifyParams{}, Options{}); err == nil {
+		t.Fatal("an undecodable event log must fail VerifyEvidence")
+	}
+}
+
+// TestVerifyEvidence_FieldSizeCap covers the per-field bound on the exported
+// entry point.
+func TestVerifyEvidence_FieldSizeCap(t *testing.T) {
+	huge := strings.Repeat("A", teetypes.MaxEvidenceFieldSize+1)
+
+	if _, err := VerifyEvidence(TdxEvidence{Quote: huge}, teetypes.VerifyParams{}, Options{}); err == nil {
+		t.Fatal("an oversized quote must be rejected")
+	}
+	ev := batchEvidence(t)[0]
+	if _, err := VerifyEvidence(TdxEvidence{Quote: ev.Quote, CCEventlog: huge}, teetypes.VerifyParams{}, Options{}); err == nil {
+		t.Fatal("an oversized cc_eventlog must be rejected")
+	}
+}
+
+func indexOf(haystack, needle []byte) int { return bytes.Index(haystack, needle) }

--- a/attestation/tdx/tdx.go
+++ b/attestation/tdx/tdx.go
@@ -26,7 +26,7 @@ import (
 // TdxEvidence is the bare-metal TDX evidence payload.
 type TdxEvidence struct {
 	Quote      string `json:"quote"`                 // base64 (std) of the DCAP quote
-	CCEventlog string `json:"cc_eventlog,omitempty"` // base64 (std), optional, not verified here
+	CCEventlog string `json:"cc_eventlog,omitempty"` // base64 (std), optional; replayed against RTMR[0-2]
 }
 
 // Options tunes DCAP verification.
@@ -44,13 +44,44 @@ type Options struct {
 }
 
 // VerifyEvidence verifies a bare-metal TDX evidence envelope and returns
-// normalized claims.
+// normalized claims. When the envelope carries a CCEL event log, it is replayed
+// against the quote's RTMRs (see ccel.go) to bind the log to the signed quote.
 func VerifyEvidence(ev TdxEvidence, params teetypes.VerifyParams, opts Options) (*teetypes.VerificationResult, error) {
+	if err := teetypes.CheckFieldSize("quote", len(ev.Quote)); err != nil {
+		return nil, fmt.Errorf("tdx: %w", err)
+	}
+	if err := teetypes.CheckFieldSize("cc_eventlog", len(ev.CCEventlog)); err != nil {
+		return nil, fmt.Errorf("tdx: %w", err)
+	}
 	quoteBytes, err := base64.StdEncoding.DecodeString(ev.Quote)
 	if err != nil {
 		return nil, fmt.Errorf("tdx: decoding quote: %w", err)
 	}
-	return VerifyQuoteBytes(quoteBytes, params, teetypes.PlatformTDX, opts)
+	res, err := VerifyQuoteBytes(quoteBytes, params, teetypes.PlatformTDX, opts)
+	if err != nil {
+		return nil, err
+	}
+	if ev.CCEventlog == "" {
+		return res, nil
+	}
+
+	ccel, err := base64.StdEncoding.DecodeString(ev.CCEventlog)
+	if err != nil {
+		return nil, fmt.Errorf("tdx: decoding cc_eventlog: %w", err)
+	}
+	// Replay against the RTMRs in the quote body, which VerifyQuoteBytes has
+	// just verified as signed.
+	rtmrs, err := quoteRTMRs(quoteBytes)
+	if err != nil {
+		return nil, err
+	}
+	rtmr3Match, err := VerifyCCELAgainstRTMRs(ccel, rtmrs[0], rtmrs[1], rtmrs[2], rtmrs[3])
+	if err != nil {
+		return nil, err
+	}
+	res.EventlogVerified = teetypes.Ptr(true)
+	res.RTMR3ReplayMatch = teetypes.Ptr(rtmr3Match)
+	return res, nil
 }
 
 // VerifyQuoteBytes verifies a raw DCAP quote: signature + PCK chain (go-tdx-guest
@@ -150,6 +181,26 @@ func validateOptions(params teetypes.VerifyParams) (*tvalidate.Options, error) {
 		opts.TdQuoteBodyOptions.Rtmrs = out
 	}
 	return opts, nil
+}
+
+// quoteRTMRs re-parses a verified quote and returns its four RTMRs. Used to
+// replay the CCEL against values the DCAP signature has already covered.
+func quoteRTMRs(quoteBytes []byte) ([4][]byte, error) {
+	var out [4][]byte
+	anyQuote, err := tabi.QuoteToProto(quoteBytes)
+	if err != nil {
+		return out, fmt.Errorf("tdx: parsing quote for RTMRs: %w", err)
+	}
+	quote, ok := anyQuote.(*tpb.QuoteV4)
+	if !ok {
+		return out, fmt.Errorf("tdx: unsupported quote type %T (only QuoteV4 is supported)", anyQuote)
+	}
+	rtmrs := quote.GetTdQuoteBody().GetRtmrs()
+	if len(rtmrs) != 4 {
+		return out, fmt.Errorf("tdx: quote has %d RTMRs (want 4)", len(rtmrs))
+	}
+	copy(out[:], rtmrs)
+	return out, nil
 }
 
 func pad(b []byte, n int) []byte {

--- a/attestation/teetypes/teetypes.go
+++ b/attestation/teetypes/teetypes.go
@@ -36,6 +36,22 @@ type AttestationEvidence struct {
 	Evidence json.RawMessage `json:"evidence"`
 }
 
+// MaxEvidenceFieldSize caps a single decoded evidence field (quote, report,
+// cert, event log, vTPM quote). The dispatcher already bounds the whole envelope
+// (teeverify.MaxEvidenceSize), but the per-platform VerifyEvidence entry points
+// are exported and may be called directly, so they bound their own fields.
+// Mirrors attestation-rs's utils::MAX_EVIDENCE_FIELD_SIZE.
+const MaxEvidenceFieldSize = 1 << 20 // 1 MiB
+
+// CheckFieldSize returns an error if an evidence field exceeds
+// MaxEvidenceFieldSize.
+func CheckFieldSize(name string, n int) error {
+	if n > MaxEvidenceFieldSize {
+		return fmt.Errorf("evidence field %q too large: %d bytes (max %d)", name, n, MaxEvidenceFieldSize)
+	}
+	return nil
+}
+
 // VerifyParams is what the caller wants checked during verification. The zero
 // value verifies the hardware signature/chain and rejects debug guests, with no
 // freshness/init-data/TCB-floor checks.
@@ -82,6 +98,17 @@ type VerificationResult struct {
 	// CollateralVerified is true when collateral (CRL/TCB/QE identity) was
 	// available and all collateral checks passed; false when skipped.
 	CollateralVerified bool `json:"collateral_verified"`
+	// EventlogVerified is nil when the evidence carried no event log. When
+	// non-nil it is true: the CCEL replayed to the quote's RTMR[0-2], binding
+	// the event log to the signed quote. A replay mismatch is returned as an
+	// error, not false.
+	EventlogVerified *bool `json:"eventlog_verified,omitempty"`
+	// RTMR3ReplayMatch is nil when the evidence carried no event log, else
+	// reports whether the replayed RTMR[3] matched the quote. False is normal
+	// and not a failure: RTMR[3] is runtime-extendable and such extends are not
+	// recorded in the CCEL. Pin RTMR[3] via VerifyParams.ExpectedRTMRs — that is
+	// checked against the signed quote — rather than relying on this field.
+	RTMR3ReplayMatch *bool `json:"rtmr3_replay_match,omitempty"`
 	// TCBStatus carries platform-specific collateral/TCB details (TDX DCAP).
 	TCBStatus *DcapVerificationStatus `json:"tcb_status,omitempty"`
 }


### PR DESCRIPTION
Follows a check-by-check audit against attestation-rs `e967531`. Closes the last "not yet ported" item in PARITY.md and two smaller gaps.

## CCEL eventlog → RTMR replay

The bare-metal TDX envelope carries `cc_eventlog`, but nothing parsed it — the blob was echoed to consumers with no cryptographic link to the signed quote. This ports attestation-rs's `tdx::ccel`: parse the TCG2 event log and replay each event into its measurement register (`RTMR_new = SHA384(RTMR_old ‖ event_digest)`), then compare against the RTMRs in the verified quote body.

Follows the ff879e5 semantics: **RTMR[0-2] enforced, RTMR[3] reported only.** RTMR[3] is the runtime-extendable register and the guest kernel's `tdx_guest` sysfs extend appends no CCEL entry, so a replay divergence there is expected on any guest that runtime-extends. Enforcing all four would reject legitimate evidence — this is why the pre-ff879e5 all-four-strict version should not be used as the reference.

**Calibration, since this is easy to overstate:** the RTMRs are ECDSA-signed by the TDX module inside the quote regardless, and `ExpectedRTMRs` already pins them fail-closed. What was missing is the integrity binding of the *supplied event log*. This is not a measurement-verification bypass.

This package is a pure library with no logger, so instead of attestation-rs's `log::warn!` the RTMR[3] outcome is surfaced programmatically, where callers can act on it:

| Field | Meaning |
|---|---|
| `EventlogVerified` | nil when no log supplied; true when the replay reproduced RTMR[0-2]. A mismatch is an error. |
| `RTMR3ReplayMatch` | nil when no log supplied, else whether RTMR[3] replayed. **False is normal, not a failure.** |

Pin RTMR[3] with `VerifyParams.ExpectedRTMRs`, which is checked against the signed quote rather than the event log.

⚠️ **Behavior change:** TDX evidence carrying a `cc_eventlog` that does not replay to RTMR[0-2] now fails verification where it previously passed silently. If any producer ships a stale or mismatched log alongside a valid quote, it will start erroring.

Scope: only bare-metal `tdx` evidence carries an event log; the az-tdx envelope has none in either implementation.

## `MinTCB.FMC` rejected instead of silently dropped

`go-sev-guest` v0.15.0's `kds.TCBParts` has no FMC field, so a caller-supplied FMC floor could not be mapped onto `validate.MinimumTCB` and was discarded **without error** — the caller believed it pinned a floor and got none. Now an explicit error.

I deliberately did not hand-roll FMC extraction from the raw `TCB_VERSION`: the byte layout differs on Turin, there is no Turin fixture to test against, and `go-sev-guest` cannot parse Turin VCEKs at all (unknown OID `1.3.6.1.4.1.3704.1.3.9`), so a Turin report fails earlier in the chain regardless. A guess would risk false rejections on a platform this repo cannot verify anyway.

## Per-field size caps

`teetypes.CheckFieldSize` (1 MiB, mirroring attestation-rs's `MAX_EVIDENCE_FIELD_SIZE`) bounds `hcl_report`, `quote`/`td_quote`/`vcek`, `cc_eventlog` and the vTPM quote fields. The dispatcher already caps the whole envelope, but the per-platform `VerifyEvidence` entry points are exported and may be called directly.

## PARITY.md rewritten

The previous revision had the direction of several divergences backwards, crediting attestation-rs as the stronger side where it is in fact the weaker one:

- expected-measurement mismatches are **advisory in Rust** (`Some(false)` + `Ok`) and **fatal here**
- Rust accepts out-of-date TDX TCB status; go-tdx-guest requires `UpToDate`
- Rust has no committed/current/launch TCB relationship checks at all
- Rust does not validate XFAM/TD_ATTRIBUTES reserved bits

Left as-is, that framing invites someone to "fix" this repo by relaxing it toward the reference — #14 already relaxed `PermitProvisionalFirmware` that way. The rewrite adds a "Where Go is ahead" section, records the Turin gap accurately (it subsumes the FMC floor gap), notes the v4-only quote support and the differing collateral defaults, and documents that the legacy GCE vTPM path is reachable through the C FFI export while pinning no VMPL and gating no debug attribute.

## Testing

CCEL replay is validated against real data: **both live fixtures in `tdx-evidence-batch.json` replay to the RTMRs signed in their own quotes.** Tests also cover:

- a tampered event digest (replay must diverge)
- each tampered boot register RTMR[0], RTMR[1], RTMR[2]
- a synthetic runtime extend of RTMR[3] (must pass, `RTMR3ReplayMatch` false)
- malformed, truncated, and out-of-range-header logs
- an all-zero-padding log that must not be mistaken for a valid replay
- the field-size caps and the `MinTCB.FMC` rejection

`go build`, `go vet`, `go test -count=1 -race ./...` and `golangci-lint run ./...` all pass.

## Related

The audit also found that **attestation-rs has the PCR[8] init-data spoof this repo fixed in #16** — `check_init_data` there indexes `tpm_pcrs[8]` with no selection-membership check. Fixed upstream in confidential-dot-ai/attestation-rs#69.

Two items are documented but deliberately untouched here: the legacy GCE vTPM path (no VMPL pin, no debug gating, reachable via `cmd/ffi`), and the fact that claims publish all PCR values without indicating which were covered by the quote's signed selection.
