### PR TITLE
fix(tdx): adapt to go-tdx-guest's per-artifact TimeSet verification time

### DIFF
--- a/attestation/tdx/tdx.go
+++ b/attestation/tdx/tdx.go
@@ -106,7 +106,7 @@ func VerifyQuoteBytes(quoteBytes []byte, params teetypes.VerifyParams, platform 
 		CheckRevocations: opts.CheckRevocations,
 		GetCollateral:    opts.GetCollateral,
 		Getter:           opts.Getter,
-		Now:              opts.Now,
+		Now:              verificationTimeSet(opts.Now),
 	}
 	if err := tverify.TdxQuote(quote, vOpts); err != nil {
 		return nil, fmt.Errorf("tdx: DCAP verification failed: %w", err)
@@ -181,6 +181,30 @@ func validateOptions(params teetypes.VerifyParams) (*tvalidate.Options, error) {
 		opts.TdQuoteBodyOptions.Rtmrs = out
 	}
 	return opts, nil
+}
+
+// verificationTimeSet maps our single verification time onto go-tdx-guest's
+// per-artifact tverify.TimeSet.
+//
+// Upstream split Options.Now from a time.Time into a *TimeSet carrying a
+// separate instant for the PCK cert chain, TCB info, QE identity, PCK CRL and
+// root CA CRL. We keep exposing one time: pinning a captured quote means
+// evaluating every artifact as of that same moment, and a caller with a reason
+// to skew them apart is better served by calling go-tdx-guest directly.
+//
+// A zero time returns nil, which upstream fills in with time.Now() for each
+// artifact — preserving this package's documented "zero → time.Now()" contract.
+func verificationTimeSet(now time.Time) *tverify.TimeSet {
+	if now.IsZero() {
+		return nil
+	}
+	return &tverify.TimeSet{
+		PckCertChain: now,
+		TcbInfo:      now,
+		QeIdentity:   now,
+		PckCrl:       now,
+		RootCaCrl:    now,
+	}
 }
 
 // quoteRTMRs re-parses a verified quote and returns its four RTMRs. Used to

--- a/attestation/tdx/tdx_test.go
+++ b/attestation/tdx/tdx_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 )
@@ -198,6 +199,60 @@ func TestVerifyEvidence_BatchFixtures(t *testing.T) {
 				t.Fatal("wrong report_data must be rejected")
 			}
 		})
+	}
+}
+
+// TestVerificationTime pins Options.Now and checks it actually reaches
+// go-tdx-guest's certificate-validity evaluation.
+//
+// go-tdx-guest v0.3.2-20250814 replaced Options.Now (time.Time) with a
+// *TimeSet carrying one instant per collateral artifact. verificationTimeSet
+// maps our single time onto all five fields; this test would fail if it
+// populated the wrong field or dropped the value, since PckCertChain is what
+// gates the offline chain check.
+func TestVerificationTime(t *testing.T) {
+	ev := batchEvidence(t)[0]
+
+	// An explicitly pinned "now" must behave like the zero value. If
+	// verificationTimeSet left PckCertChain unset, this would fail with the
+	// zero time reading as "certificate not yet valid".
+	if _, err := VerifyEvidence(ev, teetypes.VerifyParams{}, Options{Now: time.Now()}); err != nil {
+		t.Fatalf("pinning Now to the present should verify: %v", err)
+	}
+
+	// Before the PCK certificate was issued.
+	if _, err := VerifyEvidence(ev, teetypes.VerifyParams{},
+		Options{Now: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("a verification time before the PCK cert was issued must fail")
+	}
+
+	// After the PCK certificate expired.
+	if _, err := VerifyEvidence(ev, teetypes.VerifyParams{},
+		Options{Now: time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)}); err == nil {
+		t.Fatal("a verification time after the PCK cert expired must fail")
+	}
+}
+
+// TestVerificationTimeSet covers the mapping itself.
+func TestVerificationTimeSet(t *testing.T) {
+	if ts := verificationTimeSet(time.Time{}); ts != nil {
+		t.Fatalf("zero time must map to nil (upstream then defaults to now), got %+v", ts)
+	}
+	now := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	ts := verificationTimeSet(now)
+	if ts == nil {
+		t.Fatal("non-zero time must produce a TimeSet")
+	}
+	for name, got := range map[string]time.Time{
+		"PckCertChain": ts.PckCertChain,
+		"TcbInfo":      ts.TcbInfo,
+		"QeIdentity":   ts.QeIdentity,
+		"PckCrl":       ts.PckCrl,
+		"RootCaCrl":    ts.RootCaCrl,
+	} {
+		if !got.Equal(now) {
+			t.Errorf("%s = %v, want %v", name, got, now)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes the `main` build break from #20.

```
attestation/tdx/tdx.go:109:21: cannot use opts.Now (variable of struct type
time.Time) as *verify.TimeSet value in struct literal
```

## What changed upstream

go-tdx-guest `v0.3.2-20250814` replaced `verify.Options.Now` (a single `time.Time`) with a `*TimeSet` carrying a separate instant per collateral artifact:

```go
type TimeSet struct {
	PckCertChain time.Time
	TcbInfo      time.Time
	QeIdentity   time.Time
	PckCrl       time.Time
	RootCaCrl    time.Time
}
```

A nil `TimeSet` is filled in upstream with `time.Now()` for each field, which matches the old `Now.IsZero() → time.Now()` behavior.

## The fix

Keep our `Options.Now` as a single `time.Time` and translate at the boundary. Reasons for not exposing the five-field struct: it's our published API; pinning a captured quote means evaluating every artifact as of that same moment; and a caller who genuinely needs to skew them apart is better served by calling go-tdx-guest directly.

- zero time → `nil` (upstream defaults each field to now), preserving the documented `zero → time.Now()` contract
- non-zero time → all five fields set to it, matching the old single-time semantics exactly

## Testing

`Options.Now` had **no test coverage at all**, which is the more interesting problem here — this upgrade happened to fail at compile time, but a change to pinning *semantics* would have slipped through silently. So this adds real coverage rather than just unbreaking the build:

- **`TestVerificationTime`** pins `Now` on a live fixture and asserts that a time before the PCK certificate was issued and a time after it expired both fail, while an explicitly pinned present time still verifies. That last assertion is the load-bearing one: if `verificationTimeSet` left `PckCertChain` unset, the zero time would read as "certificate not yet valid" and the test would fail.
- **`TestVerificationTimeSet`** covers the mapping directly.

I validated the test the same way as the regression PoC in #19 — sabotaged `PckCertChain` and confirmed `TestVerificationTime` goes red, then restored it. A test that passes against a wrong implementation isn't worth much.

`go build`, `go vet`, `go test -count=1 -race ./...` and `golangci-lint run ./...` all pass against the upgraded dependency set.
