### PR TITLE
feat(teetypes): own the platform-family mapping

### DIFF
--- a/attestation/teetypes/platform.go
+++ b/attestation/teetypes/platform.go
@@ -1,0 +1,63 @@
+package teetypes
+
+import "strings"
+
+// Family is the hardware TEE behind a platform tag: the cloud-overlay tags
+// (az-*, gcp-*) name the same silicon as their bare-metal counterpart and are
+// verified by the same code path, so policy that is inherently
+// hardware-specific — pinning TDX RTMRs, flooring the four-component SEV-SNP
+// TCB — must key off the family, never off the tag string.
+type Family string
+
+const (
+	// FamilyUnknown is returned for any tag this module does not route to a
+	// verifier. Callers must fail closed on it: it means "no verification rules
+	// apply", not "no policy applies".
+	FamilyUnknown Family = ""
+	// FamilySNP is AMD SEV-SNP: snp, az-snp, gcp-snp.
+	FamilySNP Family = "sev-snp"
+	// FamilyTDX is Intel TDX: tdx, az-tdx, gcp-tdx.
+	FamilyTDX Family = "tdx"
+)
+
+// Family reports the hardware TEE family this module routes the tag to, and is
+// the single place that mapping is defined — teeverify's dispatcher is kept in
+// lockstep with it by test.
+//
+// A tag is an attester claim carried outside any report or transcript (see
+// PlatformType), so comparing it raw lets an attester pick "gcp-tdx" to slip
+// past a rule written for "tdx". Normalize through Family (or IsTDX/IsSNP)
+// before any platform decision.
+//
+// PlatformDstack maps to FamilyUnknown: teeverify has no dstack verifier, so no
+// verified result can carry that tag, and answering FamilyTDX would let a
+// TDX-only policy report itself as enforced against evidence this module never
+// checked.
+func (p PlatformType) Family() Family {
+	switch NormalizePlatform(string(p)) {
+	case PlatformSNP, PlatformAzSNP, PlatformGcpSNP:
+		return FamilySNP
+	case PlatformTDX, PlatformAzTDX, PlatformGcpTDX:
+		return FamilyTDX
+	default:
+		return FamilyUnknown
+	}
+}
+
+// IsTDX reports whether the tag names an Intel TDX platform this module
+// verifies. False for an unknown tag, so a TDX-only policy fails closed.
+func (p PlatformType) IsTDX() bool { return p.Family() == FamilyTDX }
+
+// IsSNP reports whether the tag names an AMD SEV-SNP platform this module
+// verifies. False for an unknown tag, so an SNP-only policy fails closed.
+func (p PlatformType) IsSNP() bool { return p.Family() == FamilySNP }
+
+// NormalizePlatform canonicalizes a platform tag read from configuration or
+// from the wire: surrounding space is trimmed and ASCII case folded, since a
+// tag differing only in those is the same platform. Nothing else is rewritten —
+// an unrecognized tag comes back as the caller wrote it (modulo trim/fold) so
+// an error message can quote what was actually supplied. Use Family on the
+// result to decide what a tag means.
+func NormalizePlatform(platform string) PlatformType {
+	return PlatformType(strings.ToLower(strings.TrimSpace(platform)))
+}

--- a/attestation/teetypes/platform_test.go
+++ b/attestation/teetypes/platform_test.go
@@ -1,0 +1,72 @@
+package teetypes
+
+import "testing"
+
+func TestFamily(t *testing.T) {
+	for _, tc := range []struct {
+		in   PlatformType
+		want Family
+	}{
+		{PlatformSNP, FamilySNP},
+		{PlatformAzSNP, FamilySNP},
+		{PlatformGcpSNP, FamilySNP},
+		{PlatformTDX, FamilyTDX},
+		{PlatformAzTDX, FamilyTDX},
+		{PlatformGcpTDX, FamilyTDX},
+		// No dstack verifier exists, so the tag must not claim a family a
+		// hardware-specific policy would then believe it enforced.
+		{PlatformDstack, FamilyUnknown},
+		{"", FamilyUnknown},
+		{"sev-snp", FamilyUnknown}, // not a tag this module emits or accepts
+		{"nitro", FamilyUnknown},
+		// Case and surrounding space are the same tag.
+		{" AZ-TDX ", FamilyTDX},
+		{"GCP-SNP", FamilySNP},
+	} {
+		if got := tc.in.Family(); got != tc.want {
+			t.Errorf("PlatformType(%q).Family() = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIsTDXAndIsSNPAreExclusiveAndFailClosed(t *testing.T) {
+	for _, p := range []PlatformType{
+		PlatformSNP, PlatformTDX, PlatformAzSNP, PlatformAzTDX,
+		PlatformGcpSNP, PlatformGcpTDX, PlatformDstack, "nitro", "",
+	} {
+		tdx, snp := p.IsTDX(), p.IsSNP()
+		if tdx && snp {
+			t.Errorf("PlatformType(%q) is both TDX and SNP", p)
+		}
+		if want := p.Family() == FamilyTDX; tdx != want {
+			t.Errorf("PlatformType(%q).IsTDX() = %v, want %v", p, tdx, want)
+		}
+		if want := p.Family() == FamilySNP; snp != want {
+			t.Errorf("PlatformType(%q).IsSNP() = %v, want %v", p, snp, want)
+		}
+	}
+	// An unroutable tag answers no to both, so a TDX-only and an SNP-only
+	// policy both refuse it rather than one of them silently applying.
+	if PlatformType("nitro").IsTDX() || PlatformType("nitro").IsSNP() {
+		t.Fatal("unknown platform must not satisfy either family")
+	}
+}
+
+func TestNormalizePlatform(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want PlatformType
+	}{
+		{"tdx", PlatformTDX},
+		{"  TDX\n", PlatformTDX},
+		{"Az-Snp", PlatformAzSNP},
+		{"", ""},
+		// Unrecognized input survives verbatim (modulo trim/fold) so callers
+		// can quote what was supplied.
+		{" Bogus ", "bogus"},
+	} {
+		if got := NormalizePlatform(tc.in); got != tc.want {
+			t.Errorf("NormalizePlatform(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/attestation/teetypes/teetypes.go
+++ b/attestation/teetypes/teetypes.go
@@ -17,6 +17,10 @@ import (
 // attester-reported claim derived from the evidence envelope, NOT a
 // cryptographic proof of cloud-provider origin. Do not grant elevated trust on
 // the platform tag alone — verify report fields (measurement, chip_id, TCB).
+//
+// Compare tags through Family/IsTDX/IsSNP rather than as strings: the cloud
+// overlays share their bare-metal counterpart's hardware and code path, so a
+// raw comparison lets an attester dodge a rule by picking a sibling tag.
 type PlatformType string
 
 const (
@@ -28,41 +32,6 @@ const (
 	PlatformGcpTDX PlatformType = "gcp-tdx"
 	PlatformDstack PlatformType = "dstack"
 )
-
-// Family is the hardware evidence family a platform tag verifies as.
-type Family string
-
-const (
-	FamilySNP Family = "sev-snp"
-	FamilyTDX Family = "tdx"
-)
-
-// Family maps a platform tag to its hardware evidence family: SEV-SNP for
-// snp/az-snp/gcp-snp, TDX for tdx/az-tdx/gcp-tdx/dstack (dstack evidence
-// carries a TDX quote). An unknown tag returns ("", false) — treat it as
-// unverifiable, never as a default family.
-func (p PlatformType) Family() (Family, bool) {
-	switch p {
-	case PlatformSNP, PlatformAzSNP, PlatformGcpSNP:
-		return FamilySNP, true
-	case PlatformTDX, PlatformAzTDX, PlatformGcpTDX, PlatformDstack:
-		return FamilyTDX, true
-	default:
-		return "", false
-	}
-}
-
-// IsSNP reports whether p verifies as SEV-SNP evidence.
-func (p PlatformType) IsSNP() bool {
-	f, ok := p.Family()
-	return ok && f == FamilySNP
-}
-
-// IsTDX reports whether p verifies as TDX evidence.
-func (p PlatformType) IsTDX() bool {
-	f, ok := p.Family()
-	return ok && f == FamilyTDX
-}
 
 // AttestationEvidence is the self-describing evidence envelope: a platform tag
 // plus the platform-specific payload, so a verifier can auto-detect the

--- a/attestation/teetypes/teetypes_test.go
+++ b/attestation/teetypes/teetypes_test.go
@@ -7,38 +7,6 @@ import (
 	"testing"
 )
 
-func TestPlatformTypeFamily(t *testing.T) {
-	tests := []struct {
-		platform PlatformType
-		family   Family
-		known    bool
-	}{
-		{PlatformSNP, FamilySNP, true},
-		{PlatformAzSNP, FamilySNP, true},
-		{PlatformGcpSNP, FamilySNP, true},
-		{PlatformTDX, FamilyTDX, true},
-		{PlatformAzTDX, FamilyTDX, true},
-		{PlatformGcpTDX, FamilyTDX, true},
-		{PlatformDstack, FamilyTDX, true},
-		{PlatformType("sev-snp"), "", false},
-		{PlatformType(""), "", false},
-	}
-	for _, tc := range tests {
-		t.Run(string(tc.platform), func(t *testing.T) {
-			family, known := tc.platform.Family()
-			if family != tc.family || known != tc.known {
-				t.Errorf("Family(%q) = %q, %v, want %q, %v", tc.platform, family, known, tc.family, tc.known)
-			}
-			if got := tc.platform.IsSNP(); got != (tc.family == FamilySNP && tc.known) {
-				t.Errorf("IsSNP(%q) = %v", tc.platform, got)
-			}
-			if got := tc.platform.IsTDX(); got != (tc.family == FamilyTDX && tc.known) {
-				t.Errorf("IsTDX(%q) = %v", tc.platform, got)
-			}
-		})
-	}
-}
-
 func tdxClaims() Claims {
 	return Claims{
 		PlatformData: map[string]any{

--- a/attestation/teeverify/teeverify.go
+++ b/attestation/teeverify/teeverify.go
@@ -52,7 +52,10 @@ func VerifyWithOptions(evidenceJSON []byte, params teetypes.VerifyParams, opts O
 		return nil, fmt.Errorf("parsing evidence envelope: %w", err)
 	}
 
-	switch env.Platform {
+	// Route on the canonicalized tag so the dispatcher accepts exactly what
+	// teetypes.NormalizePlatform/Family say a tag means; the result carries the
+	// canonical constant, never the attester's spelling.
+	switch teetypes.NormalizePlatform(string(env.Platform)) {
 	case teetypes.PlatformSNP:
 		return verifySNP(env.Evidence, params, opts.SNP, teetypes.PlatformSNP)
 	case teetypes.PlatformGcpSNP:

--- a/attestation/teeverify/teeverify_test.go
+++ b/attestation/teeverify/teeverify_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
@@ -83,5 +84,37 @@ func TestVerify_UnsupportedPlatform(t *testing.T) {
 	big := make([]byte, MaxEvidenceSize+1)
 	if _, err := Verify(big, teetypes.VerifyParams{}); err == nil {
 		t.Fatal("oversized evidence should error")
+	}
+}
+
+// TestDispatchMatchesFamily keeps the dispatcher and teetypes.Family in
+// lockstep. Downstream consumers gate hardware-specific policy (TDX RTMR pins,
+// SNP TCB floors) on Family, so a tag this package routes but Family calls
+// FamilyUnknown would be verified with that policy silently dropped — and a tag
+// Family claims but this package rejects would let a policy report itself as
+// enforceable against evidence no verifier accepts.
+func TestDispatchMatchesFamily(t *testing.T) {
+	for _, p := range []teetypes.PlatformType{
+		teetypes.PlatformSNP, teetypes.PlatformTDX,
+		teetypes.PlatformAzSNP, teetypes.PlatformAzTDX,
+		teetypes.PlatformGcpSNP, teetypes.PlatformGcpTDX,
+		teetypes.PlatformDstack,
+		" AZ-TDX ", "nitro", "",
+	} {
+		env, err := json.Marshal(teetypes.AttestationEvidence{Platform: p, Evidence: json.RawMessage(`{}`)})
+		if err != nil {
+			t.Fatalf("marshal envelope for %q: %v", p, err)
+		}
+		// Empty inner evidence never verifies; what matters is whether the
+		// dispatcher recognized the tag at all, which precedes any parsing.
+		_, err = Verify(env, teetypes.VerifyParams{})
+		if err == nil {
+			t.Fatalf("platform %q: empty evidence unexpectedly verified", p)
+		}
+		routed := !strings.Contains(err.Error(), "unsupported platform")
+		if want := p.Family() != teetypes.FamilyUnknown; routed != want {
+			t.Errorf("platform %q: dispatcher routed = %v, Family()=%q implies %v (err: %v)",
+				p, routed, p.Family(), want, err)
+		}
 	}
 }


### PR DESCRIPTION
## Why

The `platform` tag in an evidence envelope is an attester claim: it travels as plain JSON, in no report and no transcript. The cloud-overlay tags name the same silicon as their bare-metal counterpart and are verified by the same code path — `snp`/`az-snp`/`gcp-snp` all go to the SNP verifier, `tdx`/`az-tdx`/`gcp-tdx` all go to the TDX one.

So any policy that is inherently hardware-specific has to key off the *family*, never the tag string:

- pinning TDX RTMR[1]/[2] (the registers that make the guest kernel and rootfs attested at all — MRTD covers only TDVF),
- flooring the four-component SEV-SNP TCB (TDX evidence carries none of those components, and the TDX path consumes none of them).

Compare the raw string and an attester picks `gcp-tdx` to slip past a rule written for `tdx`, or picks `tdx` to trip a TDX-only rejection it wanted.

Both downstream consumers had independently arrived at that conclusion and hand-rolled the mapping — one as a string normalizer feeding an `isTDX` helper, one as `isTDXPlatform`/`isSNPPlatform` over `teetypes.PlatformType`. Counting this module's own dispatcher switch that is three copies of one table, and the table is this module's: it *is* the set of tags `teeverify` routes and the hardware each is routed to, and it changes whenever a platform is added here. A consumer cannot know a new tag appeared; it just keeps answering the old question correctly and the new one wrong, in a security gate that fails open for the family it forgot.

## What

- `teetypes.Family` (`FamilySNP`, `FamilyTDX`, `FamilyUnknown`) plus `PlatformType.Family()`, `PlatformType.IsTDX()`, `PlatformType.IsSNP()`, and `NormalizePlatform(string) PlatformType`.
- `teeverify`'s dispatcher switches on the normalized tag, so it accepts exactly what `Family` says a tag means (previously ` TDX ` was rejected as unsupported while a consumer's normalizer called it TDX). The result still carries the canonical constant, never the attester's spelling.
- `TestDispatchMatchesFamily` walks every declared tag and asserts the dispatcher routes it iff `Family() != FamilyUnknown`. That test is the point of the change: it is what makes adding a platform a single edit instead of three.

Unroutable tags — including `dstack`, which has no verifier here — answer `FamilyUnknown` and fail both `IsTDX` and `IsSNP`, so a single-family policy refuses them rather than reporting itself as enforced against evidence this module never checked.

Purely additive. No existing signature, struct field, or verdict semantic changes, so consumers can adopt it at their own pace.


## Rebase on [#25](https://github.com/confidential-dot-ai/attestation-go/pull/25)

#25 merged a first cut of these helpers; this PR now replaces them with the design above:

- The type keeps the merged name `Family` (no `teetypes.TEEFamily` stutter); everything else follows this PR.
- `Family()` returns a single value with `FamilyUnknown` instead of `(Family, bool)`, and normalizes case/space internally.
- `dstack` moves from `FamilyTDX` to `FamilyUnknown`: no dstack verifier exists here, so a family gate must refuse the tag rather than report TDX policy as enforced against evidence this module never checks.
- #25's `TestPlatformTypeFamily` is superseded by the tests in `platform_test.go`.