### PR TITLE
feat(teetypes): add platform family helpers and typed claim accessors

### DIFF
--- a/attestation/teetypes/teetypes.go
+++ b/attestation/teetypes/teetypes.go
@@ -5,6 +5,7 @@
 package teetypes
 
 import (
+	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -27,6 +28,41 @@ const (
 	PlatformGcpTDX PlatformType = "gcp-tdx"
 	PlatformDstack PlatformType = "dstack"
 )
+
+// Family is the hardware evidence family a platform tag verifies as.
+type Family string
+
+const (
+	FamilySNP Family = "sev-snp"
+	FamilyTDX Family = "tdx"
+)
+
+// Family maps a platform tag to its hardware evidence family: SEV-SNP for
+// snp/az-snp/gcp-snp, TDX for tdx/az-tdx/gcp-tdx/dstack (dstack evidence
+// carries a TDX quote). An unknown tag returns ("", false) — treat it as
+// unverifiable, never as a default family.
+func (p PlatformType) Family() (Family, bool) {
+	switch p {
+	case PlatformSNP, PlatformAzSNP, PlatformGcpSNP:
+		return FamilySNP, true
+	case PlatformTDX, PlatformAzTDX, PlatformGcpTDX, PlatformDstack:
+		return FamilyTDX, true
+	default:
+		return "", false
+	}
+}
+
+// IsSNP reports whether p verifies as SEV-SNP evidence.
+func (p PlatformType) IsSNP() bool {
+	f, ok := p.Family()
+	return ok && f == FamilySNP
+}
+
+// IsTDX reports whether p verifies as TDX evidence.
+func (p PlatformType) IsTDX() bool {
+	f, ok := p.Family()
+	return ok && f == FamilyTDX
+}
 
 // AttestationEvidence is the self-describing evidence envelope: a platform tag
 // plus the platform-specific payload, so a verifier can auto-detect the
@@ -130,6 +166,60 @@ type Claims struct {
 	TCB TcbInfo `json:"tcb"`
 	// PlatformData carries all platform-specific claim fields.
 	PlatformData map[string]any `json:"platform_data"`
+}
+
+// RTMR returns the 48-byte SHA-384 value of RTMR[i] (0..3) from the TDX
+// platform-data claims. It fails for claims without RTMRs (SNP) and for a
+// missing or malformed register claim, so a caller pinning a register fails
+// closed. Prefer VerifyParams.ExpectedRTMRs, which the verifier checks against
+// the signed quote; use this accessor to read verified claims afterwards.
+func (c Claims) RTMR(i int) ([]byte, error) {
+	if i < 0 || i > 3 {
+		return nil, fmt.Errorf("RTMR index %d out of range 0..3", i)
+	}
+	key := fmt.Sprintf("rtmr_%d", i)
+	v, ok := c.PlatformData[key].(string)
+	if !ok || v == "" {
+		return nil, fmt.Errorf("claims carry no %s", key)
+	}
+	b, err := hex.DecodeString(v)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if len(b) != sha512.Size384 {
+		return nil, fmt.Errorf("%s is %d bytes, want %d", key, len(b), sha512.Size384)
+	}
+	return b, nil
+}
+
+// DebugEnabled reports whether the evidence marks the guest debuggable: the
+// SNP guest policy debug bit, or the TDX TD_ATTRIBUTES debug bit. It fails
+// when the claims carry neither, so a caller gating on it fails closed. The
+// verifier already rejects debug guests unless VerifyParams.AllowDebug is set;
+// use this accessor for reporting or an extra gate.
+func (c Claims) DebugEnabled() (bool, error) {
+	if policy, ok := c.PlatformData["policy"].(map[string]any); ok {
+		if v, ok := policy["debug_allowed"].(bool); ok {
+			return v, nil
+		}
+	}
+	if attrs, ok := c.PlatformData["td_attributes_parsed"].(map[string]any); ok {
+		if v, ok := attrs["debug"].(bool); ok {
+			return v, nil
+		}
+	}
+	return false, fmt.Errorf("claims carry no debug flag (policy.debug_allowed or td_attributes_parsed.debug)")
+}
+
+// SMTEnabled reports whether simultaneous multithreading is enabled on the SNP
+// host. It fails for claims without SNP platform info (TDX).
+func (c Claims) SMTEnabled() (bool, error) {
+	if info, ok := c.PlatformData["platform_info"].(map[string]any); ok {
+		if v, ok := info["smt_enabled"].(bool); ok {
+			return v, nil
+		}
+	}
+	return false, fmt.Errorf("claims carry no platform_info.smt_enabled")
 }
 
 // TcbInfo is the platform-specific TCB version, tagged by Type ("Snp"/"Tdx") to

--- a/attestation/teetypes/teetypes_test.go
+++ b/attestation/teetypes/teetypes_test.go
@@ -1,0 +1,150 @@
+package teetypes
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPlatformTypeFamily(t *testing.T) {
+	tests := []struct {
+		platform PlatformType
+		family   Family
+		known    bool
+	}{
+		{PlatformSNP, FamilySNP, true},
+		{PlatformAzSNP, FamilySNP, true},
+		{PlatformGcpSNP, FamilySNP, true},
+		{PlatformTDX, FamilyTDX, true},
+		{PlatformAzTDX, FamilyTDX, true},
+		{PlatformGcpTDX, FamilyTDX, true},
+		{PlatformDstack, FamilyTDX, true},
+		{PlatformType("sev-snp"), "", false},
+		{PlatformType(""), "", false},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.platform), func(t *testing.T) {
+			family, known := tc.platform.Family()
+			if family != tc.family || known != tc.known {
+				t.Errorf("Family(%q) = %q, %v, want %q, %v", tc.platform, family, known, tc.family, tc.known)
+			}
+			if got := tc.platform.IsSNP(); got != (tc.family == FamilySNP && tc.known) {
+				t.Errorf("IsSNP(%q) = %v", tc.platform, got)
+			}
+			if got := tc.platform.IsTDX(); got != (tc.family == FamilyTDX && tc.known) {
+				t.Errorf("IsTDX(%q) = %v", tc.platform, got)
+			}
+		})
+	}
+}
+
+func tdxClaims() Claims {
+	return Claims{
+		PlatformData: map[string]any{
+			"rtmr_0":               strings.Repeat("aa", 48),
+			"rtmr_1":               strings.Repeat("bb", 48),
+			"rtmr_2":               strings.Repeat("cc", 48),
+			"rtmr_3":               strings.Repeat("dd", 48),
+			"td_attributes_parsed": map[string]any{"debug": true},
+		},
+	}
+}
+
+func snpClaims() Claims {
+	return Claims{
+		PlatformData: map[string]any{
+			"policy":        map[string]any{"debug_allowed": false},
+			"platform_info": map[string]any{"smt_enabled": true},
+		},
+	}
+}
+
+// jsonRoundTrip re-encodes claims the way a caller receiving a serialized
+// VerificationResult sees them, so the accessors must work on both shapes.
+func jsonRoundTrip(t *testing.T, c Claims) Claims {
+	t.Helper()
+	raw, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out Claims
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestClaimsRTMR(t *testing.T) {
+	for name, claims := range map[string]Claims{"in-process": tdxClaims(), "json round-trip": jsonRoundTrip(t, tdxClaims())} {
+		t.Run(name, func(t *testing.T) {
+			got, err := claims.RTMR(2)
+			if err != nil {
+				t.Fatalf("RTMR(2): %v", err)
+			}
+			if want := bytes.Repeat([]byte{0xcc}, 48); !bytes.Equal(got, want) {
+				t.Fatalf("RTMR(2) = %x, want %x", got, want)
+			}
+		})
+	}
+
+	t.Run("SNP claims fail closed", func(t *testing.T) {
+		if _, err := snpClaims().RTMR(0); err == nil || !strings.Contains(err.Error(), "no rtmr_0") {
+			t.Fatalf("RTMR(0) on SNP claims = %v, want a no-claim error", err)
+		}
+	})
+
+	for name, claims := range map[string]Claims{
+		"index out of range": tdxClaims(),
+		"not hex":            {PlatformData: map[string]any{"rtmr_1": "zz"}},
+		"wrong length":       {PlatformData: map[string]any{"rtmr_1": "aabb"}},
+		"wrong type":         {PlatformData: map[string]any{"rtmr_1": 7}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			idx := 1
+			if name == "index out of range" {
+				idx = 4
+			}
+			if _, err := claims.RTMR(idx); err == nil {
+				t.Fatalf("RTMR(%d) accepted %s", idx, name)
+			}
+		})
+	}
+}
+
+func TestClaimsDebugEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims Claims
+		want   bool
+	}{
+		{"SNP policy bit", snpClaims(), false},
+		{"TDX attribute bit", tdxClaims(), true},
+		{"SNP after JSON round-trip", jsonRoundTrip(t, snpClaims()), false},
+		{"TDX after JSON round-trip", jsonRoundTrip(t, tdxClaims()), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.claims.DebugEnabled()
+			if err != nil || got != tc.want {
+				t.Fatalf("DebugEnabled() = %v, %v, want %v, nil", got, err, tc.want)
+			}
+		})
+	}
+
+	t.Run("no flag fails closed", func(t *testing.T) {
+		if _, err := (Claims{}).DebugEnabled(); err == nil {
+			t.Fatal("DebugEnabled() on empty claims accepted, want error")
+		}
+	})
+}
+
+func TestClaimsSMTEnabled(t *testing.T) {
+	got, err := snpClaims().SMTEnabled()
+	if err != nil || !got {
+		t.Fatalf("SMTEnabled() = %v, %v, want true, nil", got, err)
+	}
+	if _, err := tdxClaims().SMTEnabled(); err == nil {
+		t.Fatal("SMTEnabled() on TDX claims accepted, want error")
+	}
+}


### PR DESCRIPTION
Adds `PlatformType.Family()` / `IsSNP()` / `IsTDX()` and `Claims.RTMR(i)` / `DebugEnabled()` / `SMTEnabled()`.

Motivation: c8s carries eight independent platform-family predicates and four independent readers of `rtmr_N` / debug / SMT flags out of the untyped `platform_data` map. These helpers give consumers one canonical spelling; all accessors fail closed on missing or malformed claims and work on both in-process and JSON-round-tripped results. `dstack` maps to the TDX family (its evidence carries a TDX quote).