### PR TITLE
feat(apiclient): pin Azure vTPM PCRs and the init-data binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ PCR pins are checked alongside the launch measurement, not instead of it, so a
 matching paravisor cannot excuse a wrong guest. Read individual registers from
 verified claims with `teetypes.Claims.PCR(i)`.
 
+The AK signature covers only the registers the quote selected; the rest of the
+bank the attester supplies is its own word. The in-process verifiers publish
+only selected registers, and `EnforcePCRs` re-reads the selection from the
+evidence, so a pin on an unselected register is refused whatever the report
+carries.
+
 Both `Policy.PCRs` and `Policy.RTMRs` refuse a pin the platform cannot answer
 rather than skipping it — reference values are per-platform, so a PCR pin
 reaching bare-metal SNP means the wrong policy was loaded, and silently passing

--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ This pins **one** measurement. A policy that accepts any of several images
 cannot be expressed server-side; use `Policy.Measurements` or `Policy.Images`
 with `VerifyEvidence`, which checks the returned report instead.
 
+### Pinning Azure vTPM PCRs
+
+On an Azure confidential VM the launch measurement covers the Microsoft
+paravisor image alone — the guest kernel and initrd measure into the **vTPM
+PCRs**. Pinning only the launch measurement there proves the paravisor booted,
+not which guest ran. `Policy.PCRs` closes that:
+
+```go
+resp, err := c.VerifyEvidence(ctx, evidence, apiclient.Policy{
+    ExpectedReportData:   expected,
+    Measurements:         launchDigests, // the paravisor
+    PCRs:                 pcrPins,       // the guest OS, SHA-256
+    ExpectedInitDataHash: initData,      // PCR[8] on az, HOST_DATA on snp, MRCONFIGID on tdx
+})
+```
+
+PCR pins are checked alongside the launch measurement, not instead of it, so a
+matching paravisor cannot excuse a wrong guest. Read individual registers from
+verified claims with `teetypes.Claims.PCR(i)`.
+
+Both `Policy.PCRs` and `Policy.RTMRs` refuse a pin the platform cannot answer
+rather than skipping it — reference values are per-platform, so a PCR pin
+reaching bare-metal SNP means the wrong policy was loaded, and silently passing
+would report it as enforced.
+
 ### Choosing an address
 
 The `/verify` verdict is not signed, so the client trusts whatever answers.

--- a/apiclient/pcr_test.go
+++ b/apiclient/pcr_test.go
@@ -29,21 +29,58 @@ func pcrKey(i int) string {
 	return "pcr" + string(rune('0'+i/10)) + string(rune('0'+i%10))
 }
 
+// azEvidence builds Azure-shaped evidence whose tpm_quote selects exactly the
+// given PCRs. The digest is not checked here; the service does that.
+func azEvidence(platform teetypes.PlatformType, selected ...int) teetypes.AttestationEvidence {
+	var bitmap [3]byte
+	for _, i := range selected {
+		bitmap[i/8] |= 1 << (i % 8)
+	}
+	var msg []byte
+	msg = append(msg, 0xFF, 0x54, 0x43, 0x47) // magic
+	msg = append(msg, 0x80, 0x18)             // TPM_ST_ATTEST_QUOTE
+	msg = append(msg, 0x00, 0x00)             // qualifiedSigner size 0
+	msg = append(msg, 0x00, 0x05, 'n', 'o', 'n', 'c', 'e')
+	msg = append(msg, make([]byte, 17)...)    // clockInfo
+	msg = append(msg, make([]byte, 8)...)     // firmwareVersion
+	msg = append(msg, 0x00, 0x00, 0x00, 0x01) // one TPMS_PCR_SELECTION
+	msg = append(msg, 0x00, 0x0B, 0x03)       // SHA-256, 3-byte bitmap
+	msg = append(msg, bitmap[:]...)
+	msg = append(msg, 0x00, 0x20)
+	msg = append(msg, make([]byte, 32)...) // pcrDigest
+	body, _ := json.Marshal(map[string]any{"tpm_quote": map[string]any{
+		"message": hex.EncodeToString(msg), "signature": "", "pcrs": []string{},
+	}})
+	return teetypes.AttestationEvidence{Platform: platform, Evidence: body}
+}
+
 func TestEnforcePCRs(t *testing.T) {
 	claims := claimsWithPCRs(map[int][]byte{4: pcr(4), 11: pcr(11)})
+	ev := azEvidence(teetypes.PlatformAzSNP, 4, 11)
 
-	if err := EnforcePCRs(claims, nil, teetypes.PlatformAzSNP); err != nil {
-		t.Errorf("EnforcePCRs(no pins) = %v, want nil", err)
-	}
-	if err := EnforcePCRs(claims, map[int][]byte{4: pcr(4), 11: pcr(11)}, teetypes.PlatformAzTDX); err != nil {
-		t.Errorf("EnforcePCRs(matching) = %v, want nil", err)
-	}
-	if err := EnforcePCRs(claims, map[int][]byte{4: pcr(9)}, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
-		t.Errorf("EnforcePCRs(mismatch) = %v, want ErrPCRNotAllowed", err)
-	}
-	// A pinned register the evidence does not carry is a refusal.
-	if err := EnforcePCRs(claims, map[int][]byte{7: pcr(7)}, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
-		t.Errorf("EnforcePCRs(unreported) = %v, want ErrPCRNotAllowed", err)
+	for _, tc := range []struct {
+		name     string
+		evidence teetypes.AttestationEvidence
+		pinned   map[int][]byte
+		want     error
+	}{
+		{"no pins", ev, nil, nil},
+		{"matching", azEvidence(teetypes.PlatformAzTDX, 4, 11), map[int][]byte{4: pcr(4), 11: pcr(11)}, nil},
+		{"mismatch", ev, map[int][]byte{4: pcr(9)}, ErrPCRNotAllowed},
+		// A pinned register the evidence does not carry is a refusal.
+		{"unreported", azEvidence(teetypes.PlatformAzSNP, 4, 7, 11), map[int][]byte{7: pcr(7)}, ErrPCRNotAllowed},
+		// The bypass: the report carries the pinned value, but the quote's
+		// signed selection excludes that register, so the value is the
+		// attester's word rather than the AK's.
+		{"reported but not signed", azEvidence(teetypes.PlatformAzSNP, 11), map[int][]byte{4: pcr(4)}, ErrPCRNotAllowed},
+		{"no tpm_quote in evidence", teetypes.AttestationEvidence{Platform: teetypes.PlatformAzSNP, Evidence: json.RawMessage(`{}`)}, map[int][]byte{4: pcr(4)}, ErrPCRNotAllowed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := EnforcePCRs(tc.evidence, claims, tc.pinned)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("EnforcePCRs() = %v, want %v", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -55,7 +92,7 @@ func TestEnforcePCRsRefusesPinsWithoutAVTPM(t *testing.T) {
 		teetypes.PlatformSNP, teetypes.PlatformTDX,
 		teetypes.PlatformGcpSNP, teetypes.PlatformGcpTDX, "nonsense",
 	} {
-		err := EnforcePCRs(claims, map[int][]byte{4: pcr(4)}, platform)
+		err := EnforcePCRs(azEvidence(platform, 4), claims, map[int][]byte{4: pcr(4)})
 		if !errors.Is(err, ErrPCRNotAllowed) {
 			t.Errorf("EnforcePCRs(pins, %q) = %v, want ErrPCRNotAllowed", platform, err)
 		}
@@ -68,20 +105,21 @@ func TestEnforcePCRsRefusesPinsWithoutAVTPM(t *testing.T) {
 func TestEnforcePinsChecksPCRsAlongsideTheLaunchMeasurement(t *testing.T) {
 	digest, _ := hex.DecodeString(digestHex)
 	resp := VerifyResponse{Result: teetypes.VerificationResult{Claims: claimsWithPCRs(map[int][]byte{4: pcr(4)})}}
+	ev := azEvidence(teetypes.PlatformAzSNP, 4)
 
 	policy := Policy{Measurements: [][]byte{digest}, PCRs: map[int][]byte{4: pcr(4)}}
-	if err := EnforcePins(resp, policy, teetypes.PlatformAzSNP); err != nil {
+	if err := EnforcePins(resp, policy, ev); err != nil {
 		t.Fatalf("EnforcePins(both matching) = %v, want nil", err)
 	}
 
 	policy.PCRs = map[int][]byte{4: pcr(0xff)}
-	if err := EnforcePins(resp, policy, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
+	if err := EnforcePins(resp, policy, ev); !errors.Is(err, ErrPCRNotAllowed) {
 		t.Fatalf("EnforcePins(good measurement, bad PCR) = %v, want ErrPCRNotAllowed", err)
 	}
 
 	// Image pins take the same treatment.
 	policy = Policy{Images: []ImagePin{{Name: "a", Digest: digest}}, PCRs: map[int][]byte{4: pcr(0xff)}}
-	if err := EnforcePins(resp, policy, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
+	if err := EnforcePins(resp, policy, ev); !errors.Is(err, ErrPCRNotAllowed) {
 		t.Fatalf("EnforcePins(image pin, bad PCR) = %v, want ErrPCRNotAllowed", err)
 	}
 }

--- a/apiclient/pcr_test.go
+++ b/apiclient/pcr_test.go
@@ -1,0 +1,115 @@
+package apiclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+)
+
+func pcr(b byte) []byte { return bytes.Repeat([]byte{b}, sha256.Size) }
+
+func claimsWithPCRs(vals map[int][]byte) teetypes.Claims {
+	tpm := map[string]any{}
+	for i, v := range vals {
+		tpm[pcrKey(i)] = hex.EncodeToString(v)
+	}
+	return teetypes.Claims{LaunchDigest: digestHex, PlatformData: map[string]any{"tpm": tpm}}
+}
+
+func pcrKey(i int) string {
+	if i < 10 {
+		return "pcr0" + string(rune('0'+i))
+	}
+	return "pcr" + string(rune('0'+i/10)) + string(rune('0'+i%10))
+}
+
+func TestEnforcePCRs(t *testing.T) {
+	claims := claimsWithPCRs(map[int][]byte{4: pcr(4), 11: pcr(11)})
+
+	if err := EnforcePCRs(claims, nil, teetypes.PlatformAzSNP); err != nil {
+		t.Errorf("EnforcePCRs(no pins) = %v, want nil", err)
+	}
+	if err := EnforcePCRs(claims, map[int][]byte{4: pcr(4), 11: pcr(11)}, teetypes.PlatformAzTDX); err != nil {
+		t.Errorf("EnforcePCRs(matching) = %v, want nil", err)
+	}
+	if err := EnforcePCRs(claims, map[int][]byte{4: pcr(9)}, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
+		t.Errorf("EnforcePCRs(mismatch) = %v, want ErrPCRNotAllowed", err)
+	}
+	// A pinned register the evidence does not carry is a refusal.
+	if err := EnforcePCRs(claims, map[int][]byte{7: pcr(7)}, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
+		t.Errorf("EnforcePCRs(unreported) = %v, want ErrPCRNotAllowed", err)
+	}
+}
+
+// A pin against a platform with no vTPM asked for a check that can never run.
+// Skipping it quietly would report the policy as enforced when it was not.
+func TestEnforcePCRsRefusesPinsWithoutAVTPM(t *testing.T) {
+	claims := claimsWithPCRs(map[int][]byte{4: pcr(4)})
+	for _, platform := range []teetypes.PlatformType{
+		teetypes.PlatformSNP, teetypes.PlatformTDX,
+		teetypes.PlatformGcpSNP, teetypes.PlatformGcpTDX, "nonsense",
+	} {
+		err := EnforcePCRs(claims, map[int][]byte{4: pcr(4)}, platform)
+		if !errors.Is(err, ErrPCRNotAllowed) {
+			t.Errorf("EnforcePCRs(pins, %q) = %v, want ErrPCRNotAllowed", platform, err)
+		}
+	}
+}
+
+// On Azure the launch measurement identifies the paravisor and the PCRs
+// identify the guest OS, so a matching launch measurement must not excuse a
+// wrong PCR.
+func TestEnforcePinsChecksPCRsAlongsideTheLaunchMeasurement(t *testing.T) {
+	digest, _ := hex.DecodeString(digestHex)
+	resp := VerifyResponse{Result: teetypes.VerificationResult{Claims: claimsWithPCRs(map[int][]byte{4: pcr(4)})}}
+
+	policy := Policy{Measurements: [][]byte{digest}, PCRs: map[int][]byte{4: pcr(4)}}
+	if err := EnforcePins(resp, policy, teetypes.PlatformAzSNP); err != nil {
+		t.Fatalf("EnforcePins(both matching) = %v, want nil", err)
+	}
+
+	policy.PCRs = map[int][]byte{4: pcr(0xff)}
+	if err := EnforcePins(resp, policy, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
+		t.Fatalf("EnforcePins(good measurement, bad PCR) = %v, want ErrPCRNotAllowed", err)
+	}
+
+	// Image pins take the same treatment.
+	policy = Policy{Images: []ImagePin{{Name: "a", Digest: digest}}, PCRs: map[int][]byte{4: pcr(0xff)}}
+	if err := EnforcePins(resp, policy, teetypes.PlatformAzSNP); !errors.Is(err, ErrPCRNotAllowed) {
+		t.Fatalf("EnforcePins(image pin, bad PCR) = %v, want ErrPCRNotAllowed", err)
+	}
+}
+
+func TestVerifyEvidenceForwardsInitDataHash(t *testing.T) {
+	s := &verifyServer{resp: okResult(teetypes.PlatformAzSNP, digestHex)}
+	yes := true
+	s.resp.Result.InitDataMatch = &yes
+	c := s.start(t)
+
+	hash := pcr(0x42)
+	ev := teetypes.AttestationEvidence{Platform: teetypes.PlatformAzSNP, Evidence: json.RawMessage(`{}`)}
+	if _, err := c.VerifyEvidence(context.Background(), ev, Policy{ExpectedInitDataHash: hash}); err != nil {
+		t.Fatalf("VerifyEvidence: %v", err)
+	}
+	if !bytes.Equal(s.got.Params.ExpectedInitDataHash, hash) {
+		t.Errorf("expected_init_data_hash = %x, want %x", s.got.Params.ExpectedInitDataHash, hash)
+	}
+}
+
+// An init-data pin the caller asked for must come back affirmatively matched.
+func TestVerifyEvidenceRefusesUnansweredInitDataPin(t *testing.T) {
+	s := &verifyServer{resp: okResult(teetypes.PlatformAzSNP, digestHex)} // InitDataMatch nil
+	c := s.start(t)
+
+	ev := teetypes.AttestationEvidence{Platform: teetypes.PlatformAzSNP, Evidence: json.RawMessage(`{}`)}
+	_, err := c.VerifyEvidence(context.Background(), ev, Policy{ExpectedInitDataHash: pcr(0x42)})
+	if !errors.Is(err, ErrInitDataMismatch) {
+		t.Fatalf("VerifyEvidence = %v, want ErrInitDataMismatch", err)
+	}
+}

--- a/apiclient/verify.go
+++ b/apiclient/verify.go
@@ -39,6 +39,11 @@ var (
 	// is from another family, where the floor pins nothing.
 	ErrMinTcbNotAllowed = errors.New("apiclient: TCB floor not allowed")
 
+	// ErrPCRNotAllowed: a pinned vTPM platform configuration register is
+	// absent, malformed, not covered by the quote's signed selection, or does
+	// not match what the policy pins.
+	ErrPCRNotAllowed = errors.New("apiclient: vTPM PCR not allowed")
+
 	// ErrInitDataMismatch: the request pinned an init-data hash and the
 	// verdict is absent or false.
 	ErrInitDataMismatch = errors.New("apiclient: init data mismatch in attestation evidence")
@@ -94,6 +99,24 @@ type Policy struct {
 	// in-guest software and cannot speak to guest identity on its own — a
 	// substituted guest extends it with whatever it likes.
 	RTMRs map[int][]byte
+
+	// PCRs pins vTPM platform configuration registers by index, and is what
+	// makes an Azure guest's OS attested rather than just Microsoft's
+	// paravisor: on an Azure confidential VM the launch measurement covers the
+	// paravisor image, while the guest kernel and initrd measure here.
+	//
+	// Values are SHA-256, 32 bytes. Pins apply only where the platform carries
+	// a vTPM quote (teetypes.PlatformType.HasVTPMQuote); elsewhere there is
+	// nothing for them to narrow, so a mixed fleet keeps working. Which
+	// indices carry guest-OS identity depends on the image's measured-boot
+	// layout.
+	PCRs map[int][]byte
+
+	// ExpectedInitDataHash, when set, is sent as expected_init_data_hash and
+	// the verdict must come back affirmatively true. The platform decides what
+	// backs it: SEV-SNP HOST_DATA, TDX MRCONFIGID zero-padded, or vTPM PCR[8]
+	// on the Azure overlays.
+	ExpectedInitDataHash []byte
 }
 
 // VerifyEnforced posts req to /verify and fails closed on the verdict
@@ -186,9 +209,10 @@ func (c Client) VerifyEvidence(ctx context.Context, evidence teetypes.Attestatio
 	}
 
 	resp, err := c.VerifyEnforced(ctx, NewVerifyRequest(evidence, &VerifyParams{
-		ExpectedReportData: policy.ExpectedReportData,
-		AllowDebug:         teetypes.Ptr(policy.AllowDebug),
-		MinTcb:             policy.MinTcb,
+		ExpectedReportData:   policy.ExpectedReportData,
+		ExpectedInitDataHash: policy.ExpectedInitDataHash,
+		AllowDebug:           teetypes.Ptr(policy.AllowDebug),
+		MinTcb:               policy.MinTcb,
 	}, false))
 	if err != nil {
 		return VerifyResponse{}, err
@@ -206,6 +230,12 @@ func (c Client) VerifyEvidence(ctx context.Context, evidence teetypes.Attestatio
 // Images are matched whole; the flat measurement/RTMR pair keeps its own path,
 // so an operator who set only that sees exactly the decisions it always made.
 func EnforcePins(resp VerifyResponse, policy Policy, platform teetypes.PlatformType) error {
+	// PCR pins are orthogonal to the launch measurement: on an Azure guest the
+	// launch measurement identifies the paravisor and the PCRs identify the
+	// guest OS, so both forms apply to the same evidence.
+	if err := EnforcePCRs(resp.Result.Claims, policy.PCRs, platform); err != nil {
+		return err
+	}
 	if len(policy.Images) > 0 {
 		return EnforceImages(resp, policy.Images, platform)
 	}
@@ -220,6 +250,39 @@ func EnforcePins(resp VerifyResponse, policy Policy, platform teetypes.PlatformT
 	if len(policy.RTMRs) > 0 {
 		return fmt.Errorf("%w: %d register(s) pinned but platform %q has none",
 			ErrRTMRNotAllowed, len(policy.RTMRs), platform)
+	}
+	return nil
+}
+
+// EnforcePCRs requires each pinned vTPM register to byte-equal what the
+// verifier reported.
+//
+// A pinned register the evidence does not carry is a refusal, not a pass. So is
+// a pin against a platform with no vTPM quote: the policy asked for a check
+// that could never run, which is a policy error rather than something to skip
+// quietly. Reference values are per-platform, so a pin reaching the wrong
+// platform means the wrong policy was loaded.
+//
+// The reported values are bound to the quote's signed PCR digest by the
+// verifier, so their integrity rests on that verifier being inside the caller's
+// trust boundary — the same footing as the launch digest.
+func EnforcePCRs(claims teetypes.Claims, pinned map[int][]byte, platform teetypes.PlatformType) error {
+	if len(pinned) == 0 {
+		return nil
+	}
+	if !platform.HasVTPMQuote() {
+		return fmt.Errorf("%w: %d register(s) pinned but platform %q carries no vTPM quote",
+			ErrPCRNotAllowed, len(pinned), platform)
+	}
+	// Sorted so the error an operator sees is stable across runs.
+	for _, idx := range slices.Sorted(maps.Keys(pinned)) {
+		got, err := claims.PCR(idx)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrPCRNotAllowed, err)
+		}
+		if !bytes.Equal(got, pinned[idx]) {
+			return fmt.Errorf("%w: PCR[%d] does not match", ErrPCRNotAllowed, idx)
+		}
 	}
 	return nil
 }

--- a/apiclient/verify.go
+++ b/apiclient/verify.go
@@ -3,12 +3,15 @@ package apiclient
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"slices"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+	"github.com/confidential-dot-ai/attestation-go/attestation/tpmcommon"
 )
 
 // Sentinel errors for the enforced verification paths, matchable with
@@ -217,7 +220,7 @@ func (c Client) VerifyEvidence(ctx context.Context, evidence teetypes.Attestatio
 	if err != nil {
 		return VerifyResponse{}, err
 	}
-	if err := EnforcePins(resp, policy, evidence.Platform); err != nil {
+	if err := EnforcePins(resp, policy, evidence); err != nil {
 		return VerifyResponse{}, err
 	}
 	return resp, nil
@@ -229,11 +232,12 @@ func (c Client) VerifyEvidence(ctx context.Context, evidence teetypes.Attestatio
 //
 // Images are matched whole; the flat measurement/RTMR pair keeps its own path,
 // so an operator who set only that sees exactly the decisions it always made.
-func EnforcePins(resp VerifyResponse, policy Policy, platform teetypes.PlatformType) error {
+func EnforcePins(resp VerifyResponse, policy Policy, evidence teetypes.AttestationEvidence) error {
+	platform := evidence.Platform
 	// PCR pins are orthogonal to the launch measurement: on an Azure guest the
 	// launch measurement identifies the paravisor and the PCRs identify the
 	// guest OS, so both forms apply to the same evidence.
-	if err := EnforcePCRs(resp.Result.Claims, policy.PCRs, platform); err != nil {
+	if err := EnforcePCRs(evidence, resp.Result.Claims, policy.PCRs); err != nil {
 		return err
 	}
 	if len(policy.Images) > 0 {
@@ -255,27 +259,38 @@ func EnforcePins(resp VerifyResponse, policy Policy, platform teetypes.PlatformT
 }
 
 // EnforcePCRs requires each pinned vTPM register to byte-equal what the
-// verifier reported.
+// verifier reported, and to be covered by the quote's signed PCR selection.
+//
+// The attester supplies the whole PCR bank alongside the quote, but the AK
+// signature covers only the registers the quote selected. A verifier that
+// publishes the bank verbatim therefore reports attester-chosen values for the
+// rest, and a guest could quote a selection that excludes the register a policy
+// pins and supply the pinned value for it. The selection is re-read here from
+// the evidence the service verified, so a pin outside it is a refusal
+// regardless of what the report carries.
 //
 // A pinned register the evidence does not carry is a refusal, not a pass. So is
 // a pin against a platform with no vTPM quote: the policy asked for a check
 // that could never run, which is a policy error rather than something to skip
 // quietly. Reference values are per-platform, so a pin reaching the wrong
 // platform means the wrong policy was loaded.
-//
-// The reported values are bound to the quote's signed PCR digest by the
-// verifier, so their integrity rests on that verifier being inside the caller's
-// trust boundary — the same footing as the launch digest.
-func EnforcePCRs(claims teetypes.Claims, pinned map[int][]byte, platform teetypes.PlatformType) error {
+func EnforcePCRs(evidence teetypes.AttestationEvidence, claims teetypes.Claims, pinned map[int][]byte) error {
 	if len(pinned) == 0 {
 		return nil
 	}
-	if !platform.HasVTPMQuote() {
+	if !evidence.Platform.HasVTPMQuote() {
 		return fmt.Errorf("%w: %d register(s) pinned but platform %q carries no vTPM quote",
-			ErrPCRNotAllowed, len(pinned), platform)
+			ErrPCRNotAllowed, len(pinned), evidence.Platform)
+	}
+	signed, err := signedPCRSelection(evidence.Evidence)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrPCRNotAllowed, err)
 	}
 	// Sorted so the error an operator sees is stable across runs.
 	for _, idx := range slices.Sorted(maps.Keys(pinned)) {
+		if !slices.Contains(signed, idx) {
+			return fmt.Errorf("%w: PCR[%d] is not in the quote's signed selection %v", ErrPCRNotAllowed, idx, signed)
+		}
 		got, err := claims.PCR(idx)
 		if err != nil {
 			return fmt.Errorf("%w: %w", ErrPCRNotAllowed, err)
@@ -285,6 +300,26 @@ func EnforcePCRs(claims teetypes.Claims, pinned map[int][]byte, platform teetype
 		}
 	}
 	return nil
+}
+
+// signedPCRSelection reads the quote's PCR selection from the tpm_quote the
+// Azure evidence carries. The service verified the AK signature over these
+// same bytes, which is what makes the selection authoritative.
+func signedPCRSelection(evidence json.RawMessage) ([]int, error) {
+	var ev struct {
+		TPMQuote *tpmcommon.RawTPMQuote `json:"tpm_quote"`
+	}
+	if err := json.Unmarshal(evidence, &ev); err != nil {
+		return nil, fmt.Errorf("evidence: %w", err)
+	}
+	if ev.TPMQuote == nil {
+		return nil, fmt.Errorf("evidence carries no tpm_quote")
+	}
+	message, err := hex.DecodeString(ev.TPMQuote.Message)
+	if err != nil {
+		return nil, fmt.Errorf("tpm_quote.message hex: %w", err)
+	}
+	return tpmcommon.SignedPCRSelection(message)
 }
 
 // EnforceRTMRs requires each pinned register to byte-equal what the service

--- a/apiclient/verify_test.go
+++ b/apiclient/verify_test.go
@@ -231,10 +231,11 @@ func TestEnforceRTMRs(t *testing.T) {
 func TestEnforcePinsRefusesRTMRPinsOnSNP(t *testing.T) {
 	resp := VerifyResponse{Result: teetypes.VerificationResult{Claims: teetypes.Claims{LaunchDigest: digestHex}}}
 	policy := Policy{RTMRs: map[int][]byte{1: make([]byte, 48)}}
-	if err := EnforcePins(resp, policy, teetypes.PlatformSNP); !errors.Is(err, ErrRTMRNotAllowed) {
+	snp := teetypes.AttestationEvidence{Platform: teetypes.PlatformSNP}
+	if err := EnforcePins(resp, policy, snp); !errors.Is(err, ErrRTMRNotAllowed) {
 		t.Fatalf("EnforcePins(snp with RTMR pins) = %v, want ErrRTMRNotAllowed", err)
 	}
-	if err := EnforcePins(resp, Policy{}, teetypes.PlatformSNP); err != nil {
+	if err := EnforcePins(resp, Policy{}, snp); err != nil {
 		t.Fatalf("EnforcePins(snp, no pins) = %v, want nil", err)
 	}
 }

--- a/attestation/teetypes/pcr_test.go
+++ b/attestation/teetypes/pcr_test.go
@@ -1,0 +1,96 @@
+package teetypes
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func pcrClaims(entries map[string]any) Claims {
+	return Claims{PlatformData: map[string]any{"tpm": entries}}
+}
+
+func TestClaimsPCR(t *testing.T) {
+	want := bytes.Repeat([]byte{0xab}, sha256.Size)
+	c := pcrClaims(map[string]any{
+		"pcr00": hex.EncodeToString(want),
+		"pcr08": hex.EncodeToString(want),
+		"pcr23": hex.EncodeToString(want),
+	})
+
+	for _, i := range []int{0, 8, 23} {
+		got, err := c.PCR(i)
+		if err != nil {
+			t.Fatalf("PCR(%d) = _, %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("PCR(%d) = %x, want %x", i, got, want)
+		}
+	}
+}
+
+// Every failure is a refusal: a caller pinning a register must never read an
+// unreported or malformed value as a pass.
+func TestClaimsPCRFailsClosed(t *testing.T) {
+	good := hex.EncodeToString(bytes.Repeat([]byte{1}, sha256.Size))
+
+	for _, tc := range []struct {
+		name   string
+		claims Claims
+		index  int
+		want   string
+	}{
+		{"index below range", pcrClaims(map[string]any{"pcr00": good}), -1, "out of range"},
+		{"index above range", pcrClaims(map[string]any{"pcr00": good}), 24, "out of range"},
+		{"no vTPM data", Claims{PlatformData: map[string]any{"rtmr_1": good}}, 1, "no vTPM data"},
+		{"nil platform data", Claims{}, 1, "no vTPM data"},
+		{"register not reported", pcrClaims(map[string]any{"pcr00": good}), 1, "no pcr01"},
+		{"empty value", pcrClaims(map[string]any{"pcr01": ""}), 1, "no pcr01"},
+		{"non-string value", pcrClaims(map[string]any{"pcr01": 7}), 1, "no pcr01"},
+		{"not hex", pcrClaims(map[string]any{"pcr01": "zz"}), 1, "pcr01"},
+		{"wrong width", pcrClaims(map[string]any{"pcr01": hex.EncodeToString([]byte{1, 2, 3})}), 1, "want 32"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.claims.PCR(tc.index)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("PCR(%d) = _, %v, want an error containing %q", tc.index, err, tc.want)
+			}
+		})
+	}
+}
+
+// A 48-byte RTMR value must not satisfy a PCR read, and vice versa: the two
+// banks use different hashes and are never interchangeable.
+func TestPCRAndRTMRWidthsDoNotCross(t *testing.T) {
+	sha384 := hex.EncodeToString(bytes.Repeat([]byte{1}, 48))
+	if _, err := pcrClaims(map[string]any{"pcr01": sha384}).PCR(1); err == nil {
+		t.Error("a 48-byte value satisfied a PCR read")
+	}
+	sha256Hex := hex.EncodeToString(bytes.Repeat([]byte{1}, sha256.Size))
+	if _, err := (Claims{PlatformData: map[string]any{"rtmr_1": sha256Hex}}).RTMR(1); err == nil {
+		t.Error("a 32-byte value satisfied an RTMR read")
+	}
+}
+
+func TestHasVTPMQuote(t *testing.T) {
+	for _, tc := range []struct {
+		platform PlatformType
+		want     bool
+	}{
+		{PlatformAzSNP, true},
+		{PlatformAzTDX, true},
+		{" AZ-TDX ", true},
+		{PlatformSNP, false},
+		{PlatformTDX, false},
+		{PlatformGcpSNP, false},
+		{PlatformGcpTDX, false},
+		{PlatformDstack, false},
+		{"nonsense", false},
+	} {
+		if got := tc.platform.HasVTPMQuote(); got != tc.want {
+			t.Errorf("PlatformType(%q).HasVTPMQuote() = %v, want %v", tc.platform, got, tc.want)
+		}
+	}
+}

--- a/attestation/teetypes/platform.go
+++ b/attestation/teetypes/platform.go
@@ -61,3 +61,18 @@ func (p PlatformType) IsSNP() bool { return p.Family() == FamilySNP }
 func NormalizePlatform(platform string) PlatformType {
 	return PlatformType(strings.ToLower(strings.TrimSpace(platform)))
 }
+
+// HasVTPMQuote reports whether verified evidence from the platform carries a
+// vTPM quote, and so the PCR bank Claims.PCR reads.
+//
+// It is a per-tag property, not a family one: the Azure overlays quote a vTPM,
+// while GCP guests expose a vTPM but attest through the native hardware
+// report, so their evidence carries no PCR bank.
+func (p PlatformType) HasVTPMQuote() bool {
+	switch NormalizePlatform(string(p)) {
+	case PlatformAzSNP, PlatformAzTDX:
+		return true
+	default:
+		return false
+	}
+}

--- a/attestation/teetypes/teetypes.go
+++ b/attestation/teetypes/teetypes.go
@@ -5,6 +5,7 @@
 package teetypes
 
 import (
+	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
@@ -167,6 +168,50 @@ func (c Claims) RTMR(i int) ([]byte, error) {
 	}
 	if len(b) != sha512.Size384 {
 		return nil, fmt.Errorf("%s is %d bytes, want %d", key, len(b), sha512.Size384)
+	}
+	return b, nil
+}
+
+// PCRCount is the number of vTPM platform configuration registers, so a valid
+// PCR index is 0 to PCRCount-1.
+const PCRCount = 24
+
+// PCR returns the 32-byte SHA-256 value of vTPM PCR[i] from the platform-data
+// claims, as tpmcommon.ApplyTPMClaims recorded it.
+//
+// On Azure confidential VMs the launch measurement covers the Microsoft
+// paravisor image alone: the guest kernel and initrd measure into these
+// registers instead. A caller that pins only the launch measurement there has
+// proved the paravisor booted, not which guest ran, so PCR pins are what make
+// an az-snp or az-tdx guest's own OS attested.
+//
+// It fails for claims from a platform with no vTPM quote (see
+// PlatformType.HasVTPMQuote) and for a missing or malformed register, so a
+// caller pinning a register fails closed rather than treating an unreported
+// value as a pass.
+//
+// Which indices carry guest-OS identity depends on the image's measured-boot
+// layout; this package does not assign meaning to an index. PCR[8] is the one
+// exception worth naming: the az verifiers bind init data through it.
+func (c Claims) PCR(i int) ([]byte, error) {
+	if i < 0 || i >= PCRCount {
+		return nil, fmt.Errorf("PCR index %d out of range 0..%d", i, PCRCount-1)
+	}
+	tpm, ok := c.PlatformData["tpm"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("claims carry no vTPM data, so PCR[%d] cannot be read", i)
+	}
+	key := fmt.Sprintf("pcr%02d", i)
+	v, ok := tpm[key].(string)
+	if !ok || v == "" {
+		return nil, fmt.Errorf("claims carry no %s", key)
+	}
+	b, err := hex.DecodeString(v)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if len(b) != sha256.Size {
+		return nil, fmt.Errorf("%s is %d bytes, want %d", key, len(b), sha256.Size)
 	}
 	return b, nil
 }

--- a/attestation/tpmcommon/tpmcommon.go
+++ b/attestation/tpmcommon/tpmcommon.go
@@ -417,6 +417,19 @@ func CheckInitData(message []byte, pcrs [][]byte, expected []byte) (*bool, error
 	return teetypes.Ptr(true), nil
 }
 
+// SignedPCRSelection returns the PCR indices the quote's signed pcrDigest
+// covers, in ascending order. Only those PCR values are authenticated by the
+// AK signature; any other value carried alongside the quote is attester-chosen.
+// Callers must have verified the quote signature first.
+func SignedPCRSelection(message []byte) ([]int, error) {
+	selected, _, err := parseQuoteInfo(message)
+	if err != nil {
+		return nil, err
+	}
+	slices.Sort(selected)
+	return selected, nil
+}
+
 func parseQuoteInfo(message []byte) ([]int, []byte, error) {
 	if len(message) < 10 {
 		return nil, nil, fmt.Errorf("TPMS_ATTEST too short")
@@ -477,10 +490,22 @@ func parseQuoteInfo(message []byte) ([]int, []byte, error) {
 // ApplyTPMClaims overlays the vTPM data onto bare-platform claims: signed_data
 // becomes the (null-trimmed) TPM nonce, and platform_data["tpm"] gets the PCR
 // bank + nonce. Mirrors attestation-rs build_tpm_verification_result.
+//
+// Only PCRs in the quote's signed selection are published. The attester
+// supplies the whole bank, but the AK signature covers just the selected
+// registers, so an unselected value is the attester's word and must not be
+// readable as a verified claim. Callers must have run VerifyTPMPCRs first; a
+// message the selection cannot be parsed from publishes no registers.
 func ApplyTPMClaims(claims *teetypes.Claims, pcrs [][]byte, message []byte) {
 	tpm := map[string]any{}
-	for i, pcr := range pcrs {
-		tpm[fmt.Sprintf("pcr%02d", i)] = hex.EncodeToString(pcr)
+	selected, err := SignedPCRSelection(message)
+	if err != nil {
+		selected = nil
+	}
+	for _, i := range selected {
+		if i < len(pcrs) {
+			tpm[fmt.Sprintf("pcr%02d", i)] = hex.EncodeToString(pcrs[i])
+		}
 	}
 	if nonce, err := ExtractTPMNonce(message); err == nil {
 		tpm["nonce"] = hex.EncodeToString(nonce)

--- a/attestation/tpmcommon/tpmcommon_test.go
+++ b/attestation/tpmcommon/tpmcommon_test.go
@@ -1,6 +1,7 @@
 package tpmcommon
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -9,7 +10,10 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"slices"
 	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 )
 
 //go:embed testdata/hcl-report.bin
@@ -225,5 +229,44 @@ func TestParseHCLReport_Fixture(t *testing.T) {
 	reportData := hcl.TEEReport[0x50 : 0x50+64]
 	if err := VerifyHCLVarDataBinding(reportData, hcl.VarData); err != nil {
 		t.Fatalf("var_data binding should hold on real evidence: %v", err)
+	}
+}
+
+// The attester supplies every PCR, but the AK signature covers only the
+// quote's selection. An unselected value is attester-chosen and must not
+// surface as a verified claim.
+func TestApplyTPMClaimsPublishesOnlySignedPCRs(t *testing.T) {
+	pcrs := zeroPCRs()
+	pcrs[4] = bytes.Repeat([]byte{4}, 32)
+	pcrs[8] = bytes.Repeat([]byte{8}, 32)
+	// Selection bitmap: PCR 0 and PCR 8 (bit 0 of byte 0, bit 0 of byte 1).
+	digest := sha256.Sum256(append(append([]byte{}, pcrs[0]...), pcrs[8]...))
+	msg := buildTPMSAttest([]byte("nonce"), []byte{0x03, 0x01, 0x01, 0x00}, digest[:])
+	if err := VerifyTPMPCRs(msg, pcrs); err != nil {
+		t.Fatalf("VerifyTPMPCRs: %v", err)
+	}
+
+	var claims teetypes.Claims
+	ApplyTPMClaims(&claims, pcrs, msg)
+	tpm := claims.PlatformData["tpm"].(map[string]any)
+	if _, ok := tpm["pcr08"]; !ok {
+		t.Error("selected pcr08 not published")
+	}
+	if _, ok := tpm["pcr00"]; !ok {
+		t.Error("selected pcr00 not published")
+	}
+	if v, ok := tpm["pcr04"]; ok {
+		t.Errorf("unselected pcr04 published as %v", v)
+	}
+	if _, err := claims.PCR(4); err == nil {
+		t.Error("Claims.PCR(4) read an unsigned register")
+	}
+	if got, err := claims.PCR(8); err != nil || !bytes.Equal(got, pcrs[8]) {
+		t.Errorf("Claims.PCR(8) = %x, %v, want %x", got, err, pcrs[8])
+	}
+
+	sel, err := SignedPCRSelection(msg)
+	if err != nil || !slices.Equal(sel, []int{0, 8}) {
+		t.Errorf("SignedPCRSelection() = %v, %v, want [0 8]", sel, err)
 	}
 }


### PR DESCRIPTION
Provides the machinery for the c8s change that replaces [c8s#456](https://github.com/confidential-dot-ai/c8s/pull/456), so that PR keeps the CLI, chart and CDS wiring and drops its verification logic.

Stacked on [#27](https://github.com/confidential-dot-ai/attestation-go/pull/27); review that first.

## Why

On an Azure confidential VM the launch measurement covers the Microsoft paravisor image alone — the guest kernel and initrd measure into the vTPM PCRs. A policy pinning only the launch measurement there proves the paravisor booted, not which guest ran.

## What

`teetypes.Claims.PCR(i)` reads `platform_data.tpm.pcrNN` with the index, presence, encoding and width checks `Claims.RTMR` already applies, at SHA-256 rather than SHA-384. `tpmcommon.ApplyTPMClaims` writes that bank, so the accessor sits beside its producer instead of being re-derived by every caller.

`PlatformType.HasVTPMQuote` says which platforms carry the bank: the Azure overlays quote a vTPM, while GCP guests expose one but attest through the native report.

`Policy.PCRs` and `Policy.ExpectedInitDataHash` reach `VerifyEvidence`. PCR pins are enforced alongside the launch measurement, not instead of it, so a matching paravisor cannot excuse a wrong guest.

## Only signed registers count

The attester supplies the whole PCR bank, but the AK signature covers only the registers in the quote's selection. Both verifiers published the bank verbatim, so a guest could quote a selection excluding a pinned register and supply the pinned value for it. `ApplyTPMClaims` now publishes only selected registers, and `EnforcePCRs` re-reads the selection from the evidence the service verified and refuses a pin outside it, which also covers a service that still publishes the full bank. `EnforcePins` takes the evidence envelope rather than a bare platform tag for that reason.

The service should apply the same filter in `build_tpm_verification_result`; that is an attestation-rs follow-up.

## Refusing unanswerable pins

A PCR pin against a platform with no vTPM is an error, not a skip — matching what [#27](https://github.com/confidential-dot-ai/attestation-go/pull/27) does for RTMR pins. c8s#456 chose to ignore them for mixed fleets; reference values are already per-platform there (`checkTEEMatchesPlatform` refuses a config written for the other platform), so a pin reaching the wrong platform means the wrong policy was loaded, and passing it silently reports a policy as enforced when nothing checked it.

Worth a deliberate look, since it is the one behavioural difference from c8s#456.
