### PR TITLE
fix(runtimemeasure): close manifest key confusion and binding fail-opens

### DIFF
--- a/runtimemeasure/binding.go
+++ b/runtimemeasure/binding.go
@@ -22,10 +22,16 @@ func Binding(r *teetypes.VerificationResult) ([]byte, error) {
 	if r == nil {
 		return nil, fmt.Errorf("no verification result")
 	}
+	if !r.SignatureValid {
+		return nil, fmt.Errorf("verification result does not carry a valid signature, so its claims are unverified")
+	}
+	if err := checkBindingPlatform(r.Platform); err != nil {
+		return nil, err
+	}
 	switch r.Platform.Family() {
 	case teetypes.FamilyTDX:
 		return r.Claims.RTMR(3)
-	case teetypes.FamilySNP:
+	default: // FamilySNP; checkBindingPlatform refused the rest.
 		// InitData is HOST_DATA on SNP. On TDX the same field is MR_CONFIG_ID
 		// at 48 bytes, which is why this arm is family-gated rather than
 		// reading InitData unconditionally.
@@ -33,36 +39,54 @@ func Binding(r *teetypes.VerificationResult) ([]byte, error) {
 			return nil, fmt.Errorf("HOSTDATA claim is %d bytes, want %d", n, HostDataSize)
 		}
 		return r.Claims.InitData, nil
-	default:
-		return nil, fmt.Errorf("platform %q: %w", r.Platform, ErrNoRegister)
 	}
+}
+
+// checkBindingPlatform refuses platforms whose evidence carries no
+// launcher-chosen binding. On az-snp the Azure paravisor owns HOSTDATA, so the
+// field says nothing about the anchor; the az verifiers bind init data through
+// vTPM PCR[8] instead, which this package does not read.
+func checkBindingPlatform(p teetypes.PlatformType) error {
+	switch p.Family() {
+	case teetypes.FamilyTDX, teetypes.FamilySNP:
+	default:
+		return fmt.Errorf("%w %q", ErrUnknownPlatform, p)
+	}
+	if teetypes.NormalizePlatform(string(p)) == teetypes.PlatformAzSNP {
+		return fmt.Errorf("platform %q: HOSTDATA is set by the Azure paravisor, not the launcher, so it carries no anchor binding: %w", p, ErrNoRegister)
+	}
+	return nil
 }
 
 // ExpectedBinding returns the value [Binding] must equal for a guest launched
 // with anchor, having measured workloadDigests in that order.
 //
 // anchor is whatever the guest was launched to trust; see [Seed]. It is hashed
-// byte for byte, so pass the exact bytes the guest committed.
+// byte for byte, so pass the exact bytes the guest committed. An empty anchor
+// is refused: its digest is a public constant, so a guest launched with an
+// empty anchor file would verify as bound to nothing in particular.
 //
 // workloadDigests are canonical "sha256:<64-hex>" strings (see
 // [CanonicalDigest]), deduplicated and in extend order. SEV-SNP has no runtime
 // extends, so a non-empty list there is a policy error rather than a value this
 // function could compute.
 func ExpectedBinding(p teetypes.PlatformType, anchor []byte, workloadDigests []string) ([]byte, error) {
-	switch p.Family() {
-	case teetypes.FamilyTDX:
+	if len(anchor) == 0 {
+		return nil, fmt.Errorf("anchor is empty; a binding to no anchor proves nothing")
+	}
+	if err := checkBindingPlatform(p); err != nil {
+		return nil, err
+	}
+	if p.Family() == teetypes.FamilyTDX {
 		reg := FromDigestsSeeded(Seed(anchor), workloadDigests)
 		return reg[:], nil
-	case teetypes.FamilySNP:
-		if len(workloadDigests) > 0 {
-			return nil, fmt.Errorf("platform %q has no runtime extends, so %d workload digest(s) cannot be measured into its binding: %w",
-				p, len(workloadDigests), ErrNoRegister)
-		}
-		hd := HostData(anchor)
-		return hd[:], nil
-	default:
-		return nil, fmt.Errorf("platform %q: %w", p, ErrNoRegister)
 	}
+	if len(workloadDigests) > 0 {
+		return nil, fmt.Errorf("platform %q has no runtime extends, so %d workload digest(s) cannot be measured into its binding: %w",
+			p, len(workloadDigests), ErrNoRegister)
+	}
+	hd := HostData(anchor)
+	return hd[:], nil
 }
 
 // VerifyBinding reports whether the guest that produced r was launched with

--- a/runtimemeasure/binding_test.go
+++ b/runtimemeasure/binding_test.go
@@ -16,7 +16,8 @@ var anchor = []byte("anchor-bytes-v1\n")
 // tdxResult builds a verified-result stand-in whose RTMR[3] claim is reg.
 func tdxResult(p teetypes.PlatformType, reg []byte) *teetypes.VerificationResult {
 	return &teetypes.VerificationResult{
-		Platform: p,
+		SignatureValid: true,
+		Platform:       p,
 		Claims: teetypes.Claims{
 			PlatformData: map[string]any{"rtmr_3": hex.EncodeToString(reg)},
 		},
@@ -25,8 +26,9 @@ func tdxResult(p teetypes.PlatformType, reg []byte) *teetypes.VerificationResult
 
 func snpResult(p teetypes.PlatformType, hostData []byte) *teetypes.VerificationResult {
 	return &teetypes.VerificationResult{
-		Platform: p,
-		Claims:   teetypes.Claims{InitData: hostData},
+		SignatureValid: true,
+		Platform:       p,
+		Claims:         teetypes.Claims{InitData: hostData},
 	}
 }
 
@@ -62,11 +64,49 @@ func TestBindingRejectsWrongWidthHostData(t *testing.T) {
 }
 
 func TestBindingUnknownPlatform(t *testing.T) {
-	if _, err := Binding(snpResult("nonsense", nil)); !errors.Is(err, ErrNoRegister) {
-		t.Errorf("Binding(unknown) = _, %v, want ErrNoRegister", err)
+	if _, err := Binding(snpResult("nonsense", nil)); !errors.Is(err, ErrUnknownPlatform) {
+		t.Errorf("Binding(unknown) = _, %v, want ErrUnknownPlatform", err)
 	}
 	if _, err := Binding(nil); err == nil {
 		t.Error("Binding(nil) = _, nil, want an error")
+	}
+}
+
+// The binding is read off claims that are only meaningful once the hardware
+// signature over them has been checked; a result saying it was not is refused.
+func TestBindingRefusesUnsignedResult(t *testing.T) {
+	seed := Seed(anchor)
+	r := tdxResult(teetypes.PlatformTDX, seed[:])
+	r.SignatureValid = false
+	if _, err := Binding(r); err == nil {
+		t.Error("Binding(SignatureValid=false) = _, nil, want an error")
+	}
+	if err := VerifyBinding(r, anchor, nil); err == nil {
+		t.Error("VerifyBinding(SignatureValid=false) = nil, want an error")
+	}
+}
+
+// On az-snp the paravisor owns HOSTDATA, so there is no launcher binding to
+// compare and the refusal must say so rather than blame the anchor.
+func TestBindingRefusesAzureSNP(t *testing.T) {
+	hostData := HostData(anchor)
+	err := VerifyBinding(snpResult(teetypes.PlatformAzSNP, hostData[:]), anchor, nil)
+	if !errors.Is(err, ErrNoRegister) || !strings.Contains(err.Error(), "paravisor") {
+		t.Errorf("VerifyBinding(az-snp) = %v, want ErrNoRegister naming the paravisor", err)
+	}
+}
+
+// An empty anchor hashes to a public constant, so a guest launched with an
+// empty anchor file must not verify as bound.
+func TestExpectedBindingRejectsEmptyAnchor(t *testing.T) {
+	for _, p := range []teetypes.PlatformType{teetypes.PlatformTDX, teetypes.PlatformSNP} {
+		if _, err := ExpectedBinding(p, nil, nil); err == nil {
+			t.Errorf("ExpectedBinding(%q, empty anchor) = _, nil, want an error", p)
+		}
+	}
+	seed := Seed(nil)
+	if err := VerifyBinding(tdxResult(teetypes.PlatformTDX, seed[:]), []byte{}, nil); err == nil {
+		t.Error("VerifyBinding with an empty anchor = nil, want an error")
 	}
 }
 
@@ -116,7 +156,10 @@ func TestBindingsAreNotInterchangeable(t *testing.T) {
 }
 
 func TestExpectedBindingUnknownPlatform(t *testing.T) {
-	if _, err := ExpectedBinding("nonsense", anchor, nil); !errors.Is(err, ErrNoRegister) {
-		t.Errorf("ExpectedBinding(unknown) = _, %v, want ErrNoRegister", err)
+	if _, err := ExpectedBinding("nonsense", anchor, nil); !errors.Is(err, ErrUnknownPlatform) {
+		t.Errorf("ExpectedBinding(unknown) = _, %v, want ErrUnknownPlatform", err)
+	}
+	if _, err := ExpectedBinding("nonsense", anchor, nil); errors.Is(err, ErrNoRegister) {
+		t.Error("ExpectedBinding(unknown) matches ErrNoRegister, so a caller skipping SNP would skip an unknown tag too")
 	}
 }

--- a/runtimemeasure/manifest.go
+++ b/runtimemeasure/manifest.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 )
 
 // ImagePins is the complete TDX measurement identity of one guest image:
@@ -55,13 +57,22 @@ func LoadImageManifest(path string) (ImagePins, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return pins, fmt.Errorf("image manifest %s is not a JSON object: %w", path, err)
 	}
-	scope := "" // top level; a confos manifest nests the tuple under "tdx"
-	if m.TDX != nil {
-		m.MRTD, m.RTMR1, m.RTMR2 = m.TDX.MRTD, m.TDX.RTMR1, m.TDX.RTMR2
-		scope = "tdx"
-	}
-	if err := rejectDuplicateRegisters(data, scope); err != nil {
+	keys, err := rejectDuplicateKeys(data)
+	if err != nil {
 		return ImagePins{}, fmt.Errorf("image manifest %s: %w", path, err)
+	}
+	if m.TDX != nil {
+		// The nested object would win over a flat tuple, so a flat register
+		// next to it is a second spelling of the same pin: refuse the
+		// ambiguity rather than pick one.
+		for _, k := range keys {
+			for _, reg := range []string{"mrtd", "rtmr1", "rtmr2"} {
+				if strings.EqualFold(k, reg) {
+					return ImagePins{}, fmt.Errorf("image manifest %s: %q is named both at the top level and under \"tdx\"; use one form", path, k)
+				}
+			}
+		}
+		m.MRTD, m.RTMR1, m.RTMR2 = m.TDX.MRTD, m.TDX.RTMR1, m.TDX.RTMR2
 	}
 	for _, f := range []struct {
 		name string
@@ -84,64 +95,69 @@ func LoadImageManifest(path string) (ImagePins, error) {
 	return pins, nil
 }
 
-// rejectDuplicateRegisters fails a manifest that names any of the three
-// register keys more than once. encoding/json silently keeps the LAST
-// occurrence, so {"mrtd":"<published>","mrtd":"<attacker>"} loads as one value
-// while a human (and any diff or signature-over-the-published-line review)
-// reads the other. Unknown extra fields stay tolerated — build manifests carry
-// plenty — but the three registers this pin is made of must be unambiguous.
-//
-// scope names the object the registers were read from: "" for the top level,
-// or "tdx" for a confos manifest that nests them. The check must follow the
-// tuple, or a duplicate inside the nested object would go unnoticed.
-func rejectDuplicateRegisters(data []byte, scope string) error {
+// rejectDuplicateKeys walks the whole document and fails on any key that
+// repeats within its object, compared the way encoding/json matches struct
+// fields: case-insensitively. Unmarshal keeps the last of two such keys, so
+// "mrtd" followed by "MRTD" loads a value other than the one a reviewer read.
+// It returns the top-level keys as written.
+func rejectDuplicateKeys(data []byte) ([]string, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, fmt.Errorf("manifest is not valid JSON: %w", err)
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, fmt.Errorf("manifest is not a JSON object")
+	}
+	return walkObject(dec)
+}
+
+// walkObject consumes an object whose opening brace has been read and returns
+// its keys.
+func walkObject(dec *json.Decoder) ([]string, error) {
+	var keys []string
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, fmt.Errorf("manifest is not valid JSON: %w", err)
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("manifest is not valid JSON: object key is %T", tok)
+		}
+		if slices.ContainsFunc(keys, func(seen string) bool { return strings.EqualFold(seen, key) }) {
+			return nil, fmt.Errorf("duplicate %q key — a key may be named only once in any letter case, since JSON parsing would silently keep the last value", key)
+		}
+		keys = append(keys, key)
+		if err := walkValue(dec); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, fmt.Errorf("manifest is not valid JSON: %w", err)
+	}
+	return keys, nil
+}
+
+// walkValue consumes one value, descending into objects and arrays so every
+// nested object is checked too.
+func walkValue(dec *json.Decoder) error {
 	tok, err := dec.Token()
 	if err != nil {
 		return fmt.Errorf("manifest is not valid JSON: %w", err)
 	}
-	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
-		return fmt.Errorf("manifest is not a JSON object")
-	}
-	seen := make(map[string]bool, 3)
-	var scoped []json.RawMessage
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return fmt.Errorf("manifest is not valid JSON: %w", err)
-		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return fmt.Errorf("manifest is not valid JSON: object key is %T", keyTok)
-		}
-		// Decode consumes the whole value, nested objects and arrays included,
-		// so the loop only ever sees top-level keys.
-		var value json.RawMessage
-		if err := dec.Decode(&value); err != nil {
-			return fmt.Errorf("manifest is not valid JSON: %w", err)
-		}
-		if scope != "" {
-			if key == scope {
-				scoped = append(scoped, value)
+	switch tok {
+	case json.Delim('{'):
+		_, err := walkObject(dec)
+		return err
+	case json.Delim('['):
+		for dec.More() {
+			if err := walkValue(dec); err != nil {
+				return err
 			}
-			continue
 		}
-		switch key {
-		case "mrtd", "rtmr1", "rtmr2":
-			if seen[key] {
-				return fmt.Errorf("duplicate %q key — a register may be named only once, since JSON parsing would silently keep the last value", key)
-			}
-			seen[key] = true
-		}
-	}
-	// Every occurrence must be collected before recursing: Unmarshal keeps the
-	// last, so checking only the first would inspect bytes the pin never loads.
-	if scope != "" {
-		if len(scoped) > 1 {
-			return fmt.Errorf("duplicate %q key — a register object may be named only once, since JSON parsing would silently keep the last value", scope)
-		}
-		if len(scoped) == 1 {
-			return rejectDuplicateRegisters(scoped[0], "")
+		if _, err := dec.Token(); err != nil {
+			return fmt.Errorf("manifest is not valid JSON: %w", err)
 		}
 	}
 	return nil

--- a/runtimemeasure/manifest_snp.go
+++ b/runtimemeasure/manifest_snp.go
@@ -76,6 +76,9 @@ func LoadSNPImageManifest(path string) (SNPImagePins, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return SNPImagePins{}, fmt.Errorf("image manifest %s is not a JSON object: %w", path, err)
 	}
+	if _, err := rejectDuplicateKeys(data); err != nil {
+		return SNPImagePins{}, fmt.Errorf("image manifest %s: %w", path, err)
+	}
 	if len(m.SNPVariants) == 0 {
 		return SNPImagePins{}, fmt.Errorf(
 			"image manifest %s: no %q — an SNP image pin is the per-SMP launch-digest set from one provenanced build-artifact manifest; a TDX tuple or a generic artifact-hash manifest.json is not it",

--- a/runtimemeasure/manifest_test.go
+++ b/runtimemeasure/manifest_test.go
@@ -24,13 +24,12 @@ func writeManifest(t *testing.T, content string) string {
 }
 
 func TestLoadImageManifestValid(t *testing.T) {
-	// Extra unknown fields are allowed: build manifests carry other data, and
-	// only the three register keys must be unambiguous — a repeated unknown
-	// key (and a nested object naming "mrtd") is none of this loader's
-	// business.
+	// Extra unknown fields are allowed: build manifests carry other data. A
+	// nested object naming "mrtd" under some other key is not the pin and is
+	// none of this loader's business.
 	p := writeManifest(t, `{
-		"schema": 3, "schema": 4,
-		"artifacts": {"kernel": "deadbeef", "mrtd": "ignored", "mrtd": "ignored"},
+		"schema": 3,
+		"artifacts": {"kernel": "deadbeef", "mrtd": "ignored"},
 		"mrtd": "`+mrtdHex+`",
 		"rtmr1": "`+rtmr1Hex+`",
 		"rtmr2": "`+rtmr2Hex+`"
@@ -93,6 +92,25 @@ func TestLoadImageManifestRejects(t *testing.T) {
 		{"duplicate rtmr2",
 			`{"mrtd":"` + mrtdHex + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `","rtmr2":"` + rtmr2Hex + `"}`,
 			`duplicate "rtmr2"`},
+		// encoding/json also matches keys case-insensitively, so a
+		// differently-cased duplicate is the same attack.
+		{"case-folded duplicate mrtd",
+			`{"mrtd":"` + mrtdHex + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `","MRTD":"` + strings.Repeat("ff", Size) + `"}`,
+			`duplicate "MRTD"`},
+		{"case-folded duplicate tdx object",
+			`{"tdx":{"mrtd":"` + mrtdHex + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `"},"TDX":{"mrtd":"` + strings.Repeat("ff", Size) + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `"}}`,
+			`duplicate "TDX"`},
+		{"case-folded duplicate inside tdx",
+			`{"tdx":{"mrtd":"` + mrtdHex + `","Mrtd":"` + strings.Repeat("ff", Size) + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `"}}`,
+			`duplicate "Mrtd"`},
+		// The nested object wins over the flat tuple, so a flat register next
+		// to it is a second spelling of the pin.
+		{"flat register beside a tdx object",
+			`{"mrtd":"` + mrtdHex + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `","tdx":{"mrtd":"` + strings.Repeat("ff", Size) + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `"}}`,
+			`both at the top level and under "tdx"`},
+		{"flat register beside an empty tdx object",
+			`{"mrtd":"` + mrtdHex + `","rtmr1":"` + rtmr1Hex + `","rtmr2":"` + rtmr2Hex + `","tdx":{}}`,
+			`both at the top level and under "tdx"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := LoadImageManifest(writeManifest(t, tc.content))
@@ -176,6 +194,11 @@ func TestLoadSNPImageManifestRejects(t *testing.T) {
 		"missing algorithm":           `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP2Digest + `"}}]}`,
 		"short digest":                `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"abcd","algorithm":"sha384"}}]}`,
 		"uppercase digest":            `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + strings.ToUpper(snpSMP2Digest) + `","algorithm":"sha384"}}]}`,
+		// Last key wins in encoding/json, at every level and in any case.
+		"duplicate snp_variants":      `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP2Digest + `","algorithm":"sha384"}}],"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP4Digest + `","algorithm":"sha384"}}]}`,
+		"case-folded duplicate list":  `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP2Digest + `","algorithm":"sha384"}}],"SNP_VARIANTS":[{"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP4Digest + `","algorithm":"sha384"}}]}`,
+		"duplicate digest in variant": `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP2Digest + `","snp_launch_digest":"` + snpSMP4Digest + `","algorithm":"sha384"}}]}`,
+		"duplicate smp in variant":    `{"snp_variants":[{"smp":4,"smp":2,"measurement":{"snp_launch_digest":"` + snpSMP2Digest + `","algorithm":"sha384"}}]}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/runtimemeasure/register.go
+++ b/runtimemeasure/register.go
@@ -14,6 +14,11 @@ import (
 // Callers gating on an extend must treat this as a hard stop, not a skip.
 var ErrNoRegister = errors.New("platform has no runtime measurement register")
 
+// ErrUnknownPlatform reports a platform tag this package has no rules for. It
+// is distinct from ErrNoRegister so a caller that skips the extend on SEV-SNP
+// does not also skip it on a mistyped or not-yet-mapped TDX tag.
+var ErrUnknownPlatform = errors.New("unknown platform")
+
 // Register is a guest's own runtime measurement register, as reached from
 // inside that guest. It is the local device; [Binding] is the remote-verifiable
 // view of the same value, read out of claims a verifier has accepted.
@@ -48,7 +53,7 @@ func Open(p teetypes.PlatformType) (Register, error) {
 		// An unrecognized tag gets no register rather than a TDX one: this
 		// module has no verifier for it, so nothing it reported could be
 		// checked anyway.
-		return nil, fmt.Errorf("unknown platform %q: %w", p, ErrNoRegister)
+		return nil, fmt.Errorf("%w %q", ErrUnknownPlatform, p)
 	}
 }
 

--- a/runtimemeasure/register_test.go
+++ b/runtimemeasure/register_test.go
@@ -14,26 +14,28 @@ import (
 func TestOpenByFamily(t *testing.T) {
 	for _, tc := range []struct {
 		platform teetypes.PlatformType
-		want     bool // a register exists
+		want     error // nil: a register exists
 	}{
-		{teetypes.PlatformTDX, true},
-		{teetypes.PlatformAzTDX, true},
-		{teetypes.PlatformGcpTDX, true},
-		{teetypes.PlatformSNP, false},
-		{teetypes.PlatformAzSNP, false},
-		{teetypes.PlatformGcpSNP, false},
-		{teetypes.PlatformDstack, false},
-		{"nonsense", false},
+		{teetypes.PlatformTDX, nil},
+		{teetypes.PlatformAzTDX, nil},
+		{teetypes.PlatformGcpTDX, nil},
+		{teetypes.PlatformSNP, ErrNoRegister},
+		{teetypes.PlatformAzSNP, ErrNoRegister},
+		{teetypes.PlatformGcpSNP, ErrNoRegister},
+		// A tag with no rules is not "SNP, nothing to extend": a caller that
+		// skips on ErrNoRegister must not skip a mistyped TDX tag.
+		{teetypes.PlatformDstack, ErrUnknownPlatform},
+		{"nonsense", ErrUnknownPlatform},
 	} {
 		reg, err := Open(tc.platform)
-		if tc.want {
+		if tc.want == nil {
 			if err != nil {
 				t.Errorf("Open(%q) = _, %v, want a register", tc.platform, err)
 			}
 			continue
 		}
-		if !errors.Is(err, ErrNoRegister) {
-			t.Errorf("Open(%q) = _, %v, want ErrNoRegister", tc.platform, err)
+		if !errors.Is(err, tc.want) {
+			t.Errorf("Open(%q) = _, %v, want %v", tc.platform, err, tc.want)
 		}
 		if reg != nil {
 			t.Errorf("Open(%q) returned a register alongside its error", tc.platform)

--- a/runtimemeasure/runtimemeasure.go
+++ b/runtimemeasure/runtimemeasure.go
@@ -116,11 +116,17 @@ const HostDataSize = 32
 //
 // It is the SNP counterpart of [Seed]. SNP has no runtime-extend register, so
 // instead of a measured initrd extending the digest after launch, the
-// (untrusted) launcher commits it at launch. The trust argument is unchanged:
-// the host can set any value, but a verifier that checks HOSTDATA against the
-// anchor it expects rejects a wrong-anchor launch, exactly as it would reject a
-// wrong RTMR[3]. A guest launched with no anchor carries all-zero HOSTDATA,
-// which no SHA-256 output equals, so that fails closed too.
+// (untrusted) launcher commits it at launch. The host can set any value, but a
+// verifier that checks HOSTDATA against the anchor it expects rejects a
+// wrong-anchor launch, exactly as it would reject a wrong RTMR[3]. A guest
+// launched with no anchor carries all-zero HOSTDATA, which no SHA-256 output
+// equals, so that fails closed too.
+//
+// What HOSTDATA proves is which anchor the launcher committed, not that the
+// guest honours it. The measured-initrd argument on TDX holds because the
+// image that hashed the anchor is the one that goes on to enforce it; on SNP
+// the verifier must also pin a launch digest of an image known to read
+// HOSTDATA and refuse any anchor that does not match it.
 //
 // anchor is the EXACT bytes committed, with the same byte-for-byte requirement
 // as [Seed].


### PR DESCRIPTION
Follow-up to [#26](https://github.com/confidential-dot-ai/attestation-go/pull/26).

## Manifest loading

`rejectDuplicateRegisters` compared keys exactly, but `encoding/json` matches struct fields case-insensitively and keeps the last value, so `{"mrtd":"<published>",…,"MRTD":"<attacker>"}` loaded the attacker's value with no error. A flat tuple beside a `"tdx"` object was overridden by the nested one without the flat keys being examined, and `LoadSNPImageManifest` had no duplicate guard at all.

Both loaders now walk the whole document and refuse any key repeated within its object in any letter case. The TDX loader refuses a flat register beside a `"tdx"` object instead of picking one. A repeated unknown key is refused too; the old test that allowed it is updated.

## Binding

- `Binding` refuses a result whose `SignatureValid` is false, as its doc already promised. The fixtures now set it.
- `ExpectedBinding` refuses an empty anchor: its digest is a public constant, so a guest launched with an empty anchor file verified as bound.
- Unknown platform tags fail with `ErrUnknownPlatform` rather than `ErrNoRegister`, so a caller that skips the extend on SEV-SNP does not skip it on a mistyped TDX tag.
- `az-snp` is refused explicitly. The Azure paravisor owns HOSTDATA (the az verifiers bind init data through vTPM PCR[8] instead), so the old comparison always failed and blamed the anchor.
- `HostData` doc: HOSTDATA proves which anchor the launcher committed, not that the guest enforces it; the pinned launch digest must be of an image that does.

Not changed: `Open(az-tdx)` still returns a TSM-backed register. Whether Azure TDX guests expose the node is unconfirmed; `Extend` fails loudly there if not.
